### PR TITLE
Carry IP addresses for each port

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -11,7 +11,7 @@ const (
 	SLEEP_INTERVAL = 1 * time.Second
 )
 
-// A Discoverer is responsible for findind services that we care
+// A Discoverer is responsible for finding services that we care
 // about. It must have a method to return the list of services, and
 // a Run() method that will be invoked when the discovery mechanism(s)
 // is/are started.

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -57,15 +57,6 @@ func Test_MultiDiscovery(t *testing.T) {
 			So(disco2.RunInvoked, ShouldBeTrue)
 		})
 
-		SkipConvey("Run() propagates the quit signal", func() {
-			multi.Run(looper)
-
-			So(disco1.RunInvoked, ShouldBeTrue)
-			So(disco2.RunInvoked, ShouldBeTrue)
-			So(<-done1, ShouldBeNil)
-			So(<-done2, ShouldBeNil)
-		})
-
 		Convey("Services() invokes the Services() method for all the discoverers", func() {
 			multi.Services()
 

--- a/discovery/docker_discovery_test.go
+++ b/discovery/docker_discovery_test.go
@@ -62,6 +62,7 @@ func Test_DockerDiscovery(t *testing.T) {
 		endpoint := "http://example.com:2375"
 		svcId1 := "deadbeef1231"
 		svcId2 := "deadbeef1011"
+		ip := "127.0.0.1"
 		baseTime := time.Now().UTC().Round(time.Second)
 		service1 := service.Service{ID: svcId1, Hostname: hostname, Updated: baseTime}
 		service2 := service.Service{ID: svcId2, Hostname: hostname, Updated: baseTime}
@@ -75,12 +76,16 @@ func Test_DockerDiscovery(t *testing.T) {
 
 		svcNamer := &RegexpNamer{ServiceNameMatch: "^/(.+)(-[0-9a-z]{7,14})$"}
 
-		disco := NewDockerDiscovery(endpoint, svcNamer)
+		disco := NewDockerDiscovery(endpoint, svcNamer, ip)
 		disco.ClientProvider = stubClientProvider
 
 		Convey("New() configures an endpoint and events channel", func() {
 			So(disco.endpoint, ShouldEqual, endpoint)
 			So(disco.events, ShouldNotBeNil)
+		})
+
+		Convey("New() sets the advertiseIp", func() {
+			So(disco.advertiseIp, ShouldEqual, ip)
 		})
 
 		Convey("Services() returns the right list of services", func() {

--- a/discovery/static_discovery.go
+++ b/discovery/static_discovery.go
@@ -23,6 +23,7 @@ type StaticDiscovery struct {
 	Targets    []*Target
 	ConfigFile string
 	Hostname   string
+	DefaultIP  string
 }
 
 type StaticCheck struct {
@@ -30,7 +31,7 @@ type StaticCheck struct {
 	Args string
 }
 
-func NewStaticDiscovery(filename string) *StaticDiscovery {
+func NewStaticDiscovery(filename string, defaultIP string) *StaticDiscovery {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Errorf("Error getting hostname! %s", err.Error())
@@ -38,6 +39,7 @@ func NewStaticDiscovery(filename string) *StaticDiscovery {
 	return &StaticDiscovery{
 		ConfigFile: filename,
 		Hostname:   hostname,
+		DefaultIP:  defaultIP,
 	}
 }
 
@@ -102,6 +104,14 @@ func (d *StaticDiscovery) ParseConfig(filename string) ([]*Target, error) {
 		if target.Service.Hostname == "" {
 			target.Service.Hostname = d.Hostname
 		}
+
+		// Make sure we have an IP address on ports
+		for i, port := range target.Service.Ports {
+			if len(port.IP) == 0 {
+				target.Service.Ports[i].IP = d.DefaultIP
+			}
+		}
+
 		log.Printf("Discovered service: %s, ID: %s",
 			target.Service.Name,
 			target.Service.ID,

--- a/discovery/static_discovery_test.go
+++ b/discovery/static_discovery_test.go
@@ -15,7 +15,8 @@ const (
 
 func Test_ParseConfig(t *testing.T) {
 	Convey("ParseConfig()", t, func() {
-		disco := NewStaticDiscovery(STATIC_JSON)
+		ip := "127.0.0.1"
+		disco := NewStaticDiscovery(STATIC_JSON, ip)
 		disco.Hostname = hostname
 
 		Convey("Errors when there is a problem with the file", func() {
@@ -39,12 +40,18 @@ func Test_ParseConfig(t *testing.T) {
 			parsed, _ := disco.ParseConfig(STATIC_HOSTNAMED_JSON)
 			So(parsed[0].Service.Hostname, ShouldEqual, "chaucer")
 		})
+
+		Convey("Assigns the default IP address when a port doesn't have one", func() {
+			parsed, _ := disco.ParseConfig(STATIC_JSON)
+			So(parsed[0].Service.Ports[0].IP, ShouldEqual, ip)
+		})
 	})
 }
 
 func Test_Services(t *testing.T) {
 	Convey("Services()", t, func() {
-		disco := NewStaticDiscovery(STATIC_JSON)
+		ip := "127.0.0.1"
+		disco := NewStaticDiscovery(STATIC_JSON, ip)
 		tgt1 := &Target{
 			Service: service.Service{ID: "asdf"},
 		}
@@ -72,7 +79,8 @@ func Test_Services(t *testing.T) {
 
 func Test_Run(t *testing.T) {
 	Convey("Run()", t, func() {
-		disco := NewStaticDiscovery(STATIC_JSON)
+		ip := "127.0.0.1"
+		disco := NewStaticDiscovery(STATIC_JSON, ip)
 		looper := director.NewFreeLooper(1, make(chan error))
 
 		Convey("Parses the specified config file", func() {

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -27,10 +27,12 @@ func Test_HAproxy(t *testing.T) {
 		svcId3 := "deadbeef105"
 		svcId4 := "deadbeef999"
 		baseTime := time.Now().UTC().Round(time.Second)
+		ip := "127.0.0.1"
+		ip3 := "127.0.0.3"
 
-		ports1 := []service.Port{{"tcp", 10450, 8080}, {"tcp", 10020, 9000}}
-		ports2 := []service.Port{{"tcp", 9999, 8090}}
-		ports3 := []service.Port{{"tcp", 32763, 8080}, {"tcp", 10020, 9000}}
+		ports1 := []service.Port{{"tcp", 10450, 8080, ip}, {"tcp", 10020, 9000, ip}}
+		ports2 := []service.Port{{"tcp", 9999, 8090, ip3}}
+		ports3 := []service.Port{{"tcp", 32763, 8080, ip3}, {"tcp", 10020, 9000, ip3}}
 
 		services := []service.Service{
 			{
@@ -110,7 +112,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: "titanic",
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
 			}
 
 			// It had 1 before
@@ -133,12 +135,13 @@ func Test_HAproxy(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(output, ShouldMatch, "frontend awesome-svc-8080")
 			So(output, ShouldMatch, "backend awesome-svc-8080")
-			So(output, ShouldMatch, "server.*indefatigable:10020")
-			So(output, ShouldMatch, "server.*indefatigable:32763")
+			So(output, ShouldMatch, "server.*indefatigable-")
+			So(output, ShouldMatch, "server.*127.0.0.1:10020")
+			So(output, ShouldMatch, "server.*127.0.0.3:32763")
 			So(output, ShouldMatch, "bind 192.168.168.168:9000")
 			So(output, ShouldMatch, "frontend some-svc-8090")
 			So(output, ShouldMatch, "backend some-svc-8090")
-			So(output, ShouldMatch, "server indefatigable-deadbeef105 indefatigable:9999 cookie indefatigable-9999")
+			So(output, ShouldMatch, "server indefatigable-deadbeef105 127.0.0.3:9999 cookie indefatigable-9999")
 		})
 
 		Convey("WriteConfig() bubbles up templater errors", func() {
@@ -157,7 +160,7 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNHEALTHY,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
 			}
 			badSvc2 := service.Service{
 				ID:       "0000bad00001",
@@ -166,7 +169,7 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNKNOWN,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
 			}
 			state.AddServiceEntry(badSvc)
 			state.AddServiceEntry(badSvc2)
@@ -227,7 +230,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: hostname2,
 				Updated:  newTime,
-				Ports:    []service.Port{{"tcp", 1337, 8090}},
+				Ports:    []service.Port{{"tcp", 1337, 8090, "127.0.0.1"}},
 			}
 			go state.AddServiceEntry(svc)
 

--- a/healthy/service_bridge_test.go
+++ b/healthy/service_bridge_test.go
@@ -132,7 +132,7 @@ func Test_ServicesBridge(t *testing.T) {
 		Convey("Responds to changes in a list of services", func() {
 			So(len(monitor.Checks), ShouldEqual, 4)
 
-			ports := []service.Port{{"udp", 11234, 8080}, {"tcp", 1234, 8081}}
+			ports := []service.Port{{"udp", 11234, 8080, "127.0.0.1"}, {"tcp", 1234, 8081, "127.0.0.1"}}
 			svc := service.Service{ID: "babbacabba", Name: "testing-12312312", Ports: ports}
 			svcList := []service.Service{svc}
 
@@ -160,8 +160,8 @@ func Test_CheckForService(t *testing.T) {
 	Convey("When building a default check", t, func() {
 		svcId1 := "deadbeef123"
 		ports := []service.Port{
-			{"udp", 11234, 8080},
-			{"tcp", 1234, 8081},
+			{"udp", 11234, 8080, "127.0.0.1"},
+			{"tcp", 1234, 8081, "127.0.0.1"},
 		}
 		service1 := service.Service{ID: svcId1, Hostname: hostname, Ports: ports}
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func configureHAproxy(config Config) *haproxy.HAproxy {
 	return proxy
 }
 
-func configureDiscovery(config *Config, opts *CliOpts) discovery.Discoverer {
+func configureDiscovery(config *Config, opts *CliOpts, publishedIP string) discovery.Discoverer {
 	disco := new(discovery.MultiDiscovery)
 
 	var svcNamer discovery.ServiceNamer
@@ -107,12 +107,12 @@ func configureDiscovery(config *Config, opts *CliOpts) discovery.Discoverer {
 		case "docker":
 			disco.Discoverers = append(
 				disco.Discoverers,
-				discovery.NewDockerDiscovery(config.DockerDiscovery.DockerURL, svcNamer),
+				discovery.NewDockerDiscovery(config.DockerDiscovery.DockerURL, svcNamer, publishedIP),
 			)
 		case "static":
 			disco.Discoverers = append(
 				disco.Discoverers,
-				discovery.NewStaticDiscovery(config.StaticDiscovery.ConfigFile),
+				discovery.NewStaticDiscovery(config.StaticDiscovery.ConfigFile, publishedIP),
 			)
 		default:
 		}
@@ -286,7 +286,7 @@ func main() {
 	// Register the cluster name with the state object
 	state.ClusterName = *opts.ClusterName
 
-	disco := configureDiscovery(&config, opts)
+	disco := configureDiscovery(&config, opts, publishedIP)
 	go disco.Run(discoLooper)
 
 	// Configure the monitor and use the public address as the default

--- a/views/haproxy.cfg
+++ b/views/haproxy.cfg
@@ -55,6 +55,6 @@ frontend {{ sanitizeName $svcName }}-{{ $svcPort }}
 
 backend {{ sanitizeName $svcName }}-{{ $svcPort }}
 	mode {{ getMode $svcName }} {{ range $svc := $services }}
-	server {{ $svc.Hostname }}-{{ $svc.ID }} {{ $svc.Hostname }}:{{ portFor $svcPort $svc }} cookie {{ $svc.Hostname }}-{{ portFor $svcPort $svc }} {{ end }}
+	server {{ $svc.Hostname }}-{{ $svc.ID }} {{ ipFor $svcPort $svc }}:{{ portFor $svcPort $svc }} cookie {{ $svc.Hostname }}-{{ portFor $svcPort $svc }} {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This is a really important change. 

1. This will prevent issues where hosts have short names and where the search domains don't match on the Sidecar hosts. 
2. It allows for hosts to have multiple interfaces and export the containers on the specified port. 
3. It paves the way for Sidecar to serve DNS SRV records. It will be able to provide sidecar-specific hostnames that point to proper IP addresses.

Static discovery will use any provided ports or will use the default published IP when this is not specified. HAproxy will default to using the hostname as beforewhen the ports do not have IPs specified. When a Docker container reports a port with an IP address of `0.0.0.0`, `DockerDiscovery` will instead replace it with the default published IP address.

@felixgborrego @mihaitodor @bparli @intjonathan