### PR TITLE
Add watcher by_service optional query parameter

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -1,4 +1,5 @@
 package catalog
+
 //go:generate ffjson $GOFILE
 
 import (
@@ -278,7 +279,6 @@ func (state *ServicesState) AddServiceEntry(entry service.Service) {
 		// by sending them the record. We're saved from an endless
 		// retransmit loop by the Invalidates() call above.
 		state.retransmit(entry)
-		return
 	}
 }
 

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -204,26 +204,14 @@ func Test_ServicesStateWithData(t *testing.T) {
 				So(string(packet[0]), ShouldEqual, string(encoded))
 			})
 
-			Convey("Doesn't retransmit when the state is the same", func() {
-				state.Broadcasts = make(chan [][]byte, 2)
-				state.AddServiceEntry(svc)
-
-				<-state.Broadcasts
-
-				svc.Updated = svc.Updated.Add(1 * time.Second)
-				state.AddServiceEntry(svc)
-
-				time.Sleep(5 * time.Millisecond)
-
-				So(len(state.Broadcasts), ShouldEqual, 0)
-			})
-
 			Convey("Doesn't retransmit an add of a new service for this host", func() {
 				state.Hostname = hostname
 				state.Broadcasts = make(chan [][]byte, 1)
 				svc.Hostname = hostname
 				state.AddServiceEntry(svc)
 
+				// state.AddServiceEntry() triggers state.retransmit(), which spins up
+				// a goroutine to publish broadcasts if svc.Hostname != state.Hostname
 				pendingBroadcast := false
 				select {
 				case <-state.Broadcasts:


### PR DESCRIPTION
- when invoking `/watcher?by_service=false`, return the entire
state instead of `state.ByService()`
- add unit tests for the watcher handler

Note: the `params` parameter of `watchHandler` won't receive the HTTP query parameters, so I had to extract `by_service` from `req.URL.Query()`.