### PR TITLE
Fix haproxy restart

### DIFF
--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -248,13 +248,7 @@ func (h *HAproxy) run(command string) error {
 		h.signalsHandled = true
 	}
 
-	err := cmd.Start()
-
-	if err != nil {
-		return fmt.Errorf("Unable to start '%s': %s", command, err)
-	}
-
-	err = cmd.Wait()
+	err := cmd.Run()
 
 	if err != nil {
 		err = fmt.Errorf("Error running '%s': %s\n%s\n%s", command, err, stdout, stderr)

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -21,10 +21,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-const (
-	RESTART_TIMEOUT = 5 * time.Second
-)
-
 type portset map[string]string
 type portmap map[string]portset
 

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -81,6 +81,8 @@ func Test_HAproxy(t *testing.T) {
 		proxy.BindIP = "192.168.168.168"
 		proxy.Template = "../views/haproxy.cfg"
 
+		proxy.ResetSignals()
+
 		Convey("New() returns a properly configured struct", func() {
 			p := New("tmpConfig", "tmpPid")
 			So([]byte(p.ReloadCmd), ShouldMatch, "^haproxy .*")


### PR DESCRIPTION
This fixes a weird issue where, now that we're grabbing output from the HAproxy commands, SIGSTOP, SIGTSTP, SIGTTOU, and SIGTTIN signals are getting propagated up from the shell and HAproxy commands and causing the process to stop. The solution is to swallow those signals while the command is running. The implementation here lazily begins intercepting them and will continue to do so until `ResetSignals()` is called.

It's important to note that `ResetSignals()` could remove other signal handlers that have been installed on these signals in other parts of the program! Also, access to manipulating the signal handling is synchronized with a mutex. This is held locked the entire time the external executable is running because we can't risk having them turned off while it's still running and potentially propagating signals. The end effect is that only one command can be running at a time. Which in our use case is perfectly acceptable, even desirable.

I had tried other solutions like putting the child in its own process group and disabling the controlling tty for the child, but was unable to stop the signal propagation in Go. I wish there were something cleaner here.

Includes minor fix for annoying warning on startup as well.

@felixgborrego @mihaitodor 