### PR TITLE
Fix receiver to queue updates not run directly

### DIFF
--- a/receiver/http.go
+++ b/receiver/http.go
@@ -47,7 +47,7 @@ func UpdateHandler(response http.ResponseWriter, req *http.Request, rcvr *Receiv
 				log.Errorf("No OnUpdate() callback registered!")
 				return
 			}
-			rcvr.OnUpdate(rcvr.CurrentState)
+			rcvr.EnqueueUpdate()
 		}
 	}
 }


### PR DESCRIPTION
Fixes a glaring error where the receiver was directly triggering updates rather than enqueuing them and therefore both causing many more reloads than necessary, but also potentially triggering them out of order.

@felixgborrego 