### PR TITLE
Add Envoy proxy API

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 	"github.com/Nitro/sidecar/healthy"
 	"github.com/Nitro/sidecar/service"
 	"github.com/Nitro/sidecar/sidecarhttp"
-	log "github.com/sirupsen/logrus"
 	"github.com/armon/go-metrics"
 	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/relistan/rubberneck.v1"
 )
 
@@ -359,7 +359,10 @@ func main() {
 	go monitor.Watch(disco, healthWatchLooper)
 	go monitor.Run(healthLooper)
 
-	go sidecarhttp.ServeHttp(list, state)
+	go sidecarhttp.ServeHttp(list, state, &sidecarhttp.HttpConfig{
+		BindIP:       config.HAproxy.BindIP,
+		UseHostnames: config.HAproxy.UseHostnames,
+	})
 
 	if !config.HAproxy.Disable {
 		proxy.WriteAndReload(state)

--- a/service/service.go
+++ b/service/service.go
@@ -99,6 +99,17 @@ func (svc *Service) ListenerName() string {
 	return "Service(" + svc.Name + "-" + svc.ID + ")"
 }
 
+// Version attempts to extract a version from the image. Otherwise it returns
+// the full image name.
+func (svc *Service) Version() string {
+	parts := strings.Split(svc.Image, ":")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+
+	return parts[0]
+}
+
 func Decode(data []byte) *Service {
 	var svc Service
 	svc.UnmarshalJSON(data)

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -1,0 +1,408 @@
+package sidecarhttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"strconv"
+	"strings"
+
+	"github.com/Nitro/memberlist"
+	"github.com/Nitro/sidecar/catalog"
+	"github.com/Nitro/sidecar/service"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Used to join service name and port. Must not occur in service names
+	ServiceNameSeparator = ":"
+)
+
+// This file implements the Envoy proxy V1 API on top of a Sidecar
+// service discovery cluster.
+
+// See https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds.html
+type EnvoyService struct {
+	IPAddress       string            `json:"ip_address"`
+	LastCheckIn     string            `json:"last_check_in"`
+	Port            int64             `json:"port"`
+	Revision        string            `json:"revision"`
+	Service         string            `json:"service"`
+	ServiceRepoName string            `json:"service_repo_name"`
+	Tags            map[string]string `json:"tags"`
+}
+
+// See https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster.html
+type EnvoyCluster struct {
+	Name             string `json:"name"`
+	Type             string `json:"type"`
+	ConnectTimeoutMs int64  `json:"connect_timeout_ms"`
+	LBType           string `json:"lb_type"`
+	ServiceName      string `json:"service_name"`
+	// Many optional fields omitted
+}
+
+// https://www.envoyproxy.io/docs/envoy/latest/api-v1/listeners/listeners.html
+type EnvoyListener struct {
+	Name    string         `json:"name"`
+	Address string         `json:"address"`
+	Filters []*EnvoyFilter `json:"filters"` // TODO support filters?
+	// Many optional fields omitted
+}
+
+// A basic Envoy Http Route Filter
+type EnvoyFilter struct {
+	Name   string                 `json:"name"`
+	Config *EnvoyHttpFilterConfig `json:"config"`
+}
+
+type EnvoyHttpFilterConfig struct {
+	CodecType   string            `json:"codec_type,omitempty"`
+	StatPrefix  string            `json:"stat_prefix,omitempty"`
+	RouteConfig *EnvoyRouteConfig `json:"route_config,omitempty"`
+	Filters     []*EnvoyFilter    `json:"filters,omitempty"`
+}
+
+type EnvoyVirtualHost struct {
+	Name    string        `json:"name"`
+	Domains []string      `json:"domains"`
+	Routes  []*EnvoyRoute `json:"routes"`
+}
+
+type EnvoyRouteConfig struct {
+	VirtualHosts []*EnvoyVirtualHost `json:"virtual_hosts"`
+}
+
+type EnvoyRoute struct {
+	TimeoutMs   int    `json:"timeout_ms"`
+	Prefix      string `json:"prefix"`
+	HostRewrite string `json:"host_rewrite"`
+	Cluster     string `json:"cluster"`
+}
+
+type EnvoyApi struct {
+	list   *memberlist.Memberlist
+	state  *catalog.ServicesState
+	config *HttpConfig
+}
+
+// optionsHandler sends CORS headers
+func (s *EnvoyApi) optionsHandler(response http.ResponseWriter, req *http.Request) {
+	response.Header().Set("Access-Control-Allow-Origin", "*")
+	response.Header().Set("Access-Control-Allow-Methods", "GET")
+	return
+}
+
+// registrationHandler takes the name of a single service and returns results for just
+// that service. It implements the Envoy SDS API V1.
+func (s *EnvoyApi) registrationHandler(response http.ResponseWriter, req *http.Request, params map[string]string) {
+	defer req.Body.Close()
+
+	response.Header().Set("Content-Type", "application/json")
+
+	name, ok := params["service"]
+	if !ok {
+		log.Debug("No service name provided to Envoy registrationHandler")
+		sendJsonError(response, 404, "Not Found - No service name provided")
+		return
+	}
+
+	svcName, svcPort, err := SvcNameSplit(name)
+	if err != nil {
+		log.Debugf("Envoy Service '%s' not found in registrationHandler: %s", name, err)
+		sendJsonError(response, 404, "Not Found - "+err.Error())
+		return
+	}
+
+	var instances []*EnvoyService
+
+	// Enter critical section
+	func() {
+		s.state.RLock()
+		defer s.state.RUnlock()
+		s.state.EachService(func(hostname *string, id *string, svc *service.Service) {
+			if svc.Name == svcName {
+				instances = append(instances, s.EnvoyServiceFromService(svc, svcPort))
+			}
+		})
+	}()
+
+	// Did we have any entries for this service in the catalog?
+	if len(instances) == 0 {
+		log.Debugf("Envoy Service '%s' has no instances!", name)
+		sendJsonError(response, 404, fmt.Sprintf("no instances of %s found", name))
+		return
+	}
+
+	clusterName := ""
+	if s.list != nil {
+		clusterName = s.list.ClusterName()
+	}
+
+	result := struct {
+		Env     string          `json:"env"`
+		Hosts   []*EnvoyService `json:"hosts"`
+		Service string          `json:"service"`
+	}{
+		clusterName,
+		instances,
+		name,
+	}
+
+	jsonBytes, err := json.MarshalIndent(&result, "", "  ")
+	if err != nil {
+		log.Errorf("Error marshaling state in registrationHandler: %s", err.Error())
+		sendJsonError(response, 500, "Internal server error")
+		return
+	}
+
+	response.Write(jsonBytes)
+}
+
+// clustersHandler returns cluster information for all Sidecar services. It
+// implements the Envoy CDS API V1.
+func (s *EnvoyApi) clustersHandler(response http.ResponseWriter, req *http.Request, params map[string]string) {
+	defer req.Body.Close()
+
+	response.Header().Set("Content-Type", "application/json")
+
+	clusters := s.EnvoyClustersFromState()
+
+	log.Debugf("Reporting Envoy cluster information for cluster '%s' and node '%s'",
+		params["service_cluster"], params["service_node"])
+
+	result := struct {
+		Clusters []*EnvoyCluster `json:"clusters"`
+	}{
+		clusters,
+	}
+
+	jsonBytes, err := json.MarshalIndent(&result, "", "  ")
+
+	if err != nil {
+		log.Errorf("Error marshaling state in servicesHandler: %s", err.Error())
+		sendJsonError(response, 500, "Internal server error")
+		return
+	}
+
+	response.Write(jsonBytes)
+}
+
+// listenersHandler returns a list of listeners for all ServicePorts. It
+// implements the Envoy LDS API V1.
+func (s *EnvoyApi) listenersHandler(response http.ResponseWriter, req *http.Request, params map[string]string) {
+	defer req.Body.Close()
+
+	response.Header().Set("Content-Type", "application/json")
+
+	log.Debugf("Reporting Envoy cluster information for cluster '%s' and node '%s'",
+		params["service_cluster"], params["service_node"])
+
+	listeners := s.EnvoyListenersFromState()
+
+	result := struct {
+		Listeners []*EnvoyListener `json:"listeners"`
+	}{
+		listeners,
+	}
+
+	jsonBytes, err := json.MarshalIndent(&result, "", "  ")
+
+	if err != nil {
+		log.Errorf("Error marshaling state in servicesHandler: %s", err.Error())
+		sendJsonError(response, 500, "Internal server error")
+		return
+	}
+
+	response.Write(jsonBytes)
+}
+
+// EnvoyServiceFromService converts a Sidecar service to an Envoy
+// API service for reporting to the proxy
+func (s *EnvoyApi) EnvoyServiceFromService(svc *service.Service, svcPort int64) *EnvoyService {
+	if len(svc.Ports) < 1 {
+		return nil
+	}
+
+	for _, port := range svc.Ports {
+		// No sense worrying about unexposed ports
+		if port.ServicePort == svcPort {
+			return &EnvoyService{
+				IPAddress:       port.IP,
+				LastCheckIn:     svc.Updated.String(),
+				Port:            port.Port,
+				Revision:        svc.Version(),
+				Service:         SvcName(svc.Name, port.ServicePort),
+				ServiceRepoName: svc.Image,
+				Tags:            map[string]string{},
+			}
+		}
+	}
+
+	return nil
+}
+
+// EnvoyClustersFromState genenerates a set of Envoy API cluster
+// definitions from Sidecar state
+func (s *EnvoyApi) EnvoyClustersFromState() []*EnvoyCluster {
+	var clusters []*EnvoyCluster
+
+	s.state.RLock()
+	defer s.state.RUnlock()
+
+	svcs := s.state.ByService()
+	for svcName, endpoints := range svcs {
+		if len(endpoints) < 1 {
+			continue
+		}
+
+		var svc *service.Service
+		for _, endpoint := range endpoints {
+			if endpoint.IsAlive() {
+				svc = endpoint
+				break
+			}
+		}
+
+		if svc == nil {
+			continue
+		}
+
+		for _, port := range svc.Ports {
+			if port.ServicePort < 1 {
+				continue
+			}
+
+			clusters = append(clusters, &EnvoyCluster{
+				Name:             SvcName(svcName, port.ServicePort),
+				Type:             "sds", // use Sidecar's SDS endpoint for the hosts
+				ConnectTimeoutMs: 500,
+				LBType:           "round_robin", // TODO figure this out!
+				ServiceName:      SvcName(svcName, port.ServicePort),
+			})
+		}
+	}
+
+	return clusters
+}
+
+func (s *EnvoyApi) EnvoyListenerFromService(svc *service.Service, port int64) *EnvoyListener {
+	apiName := SvcName(svc.Name, port)
+	// Holy indentation, Bat Man!
+	return &EnvoyListener{
+		Name: apiName,
+		// TODO need to do something similar to HAPROXY_USE_HOSTNAMES here
+		Address: fmt.Sprintf("tcp://%s:%d", s.config.BindIP, port),
+		Filters: []*EnvoyFilter{
+			{
+				Name: "envoy.http_connection_manager",
+				Config: &EnvoyHttpFilterConfig{
+					CodecType:  "auto",
+					StatPrefix: "ingress_http",
+					Filters: []*EnvoyFilter{
+						{
+							Name: "router",
+							Config: &EnvoyHttpFilterConfig{},
+						},
+					},
+					RouteConfig: &EnvoyRouteConfig{
+						VirtualHosts: []*EnvoyVirtualHost{
+							{
+								Name:    svc.Name,
+								Domains: []string{"*"},
+								Routes: []*EnvoyRoute{
+									{
+										TimeoutMs: 0, // No timeout!
+										Prefix:    "/",
+										Cluster:   apiName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// EnvoyListenersFromState creates a set of Enovy API listener
+// definitions from all the ServicePorts in the Sidecar state.
+func (s *EnvoyApi) EnvoyListenersFromState() []*EnvoyListener {
+	var listeners []*EnvoyListener
+
+	s.state.RLock()
+	defer s.state.RUnlock()
+
+	svcs := s.state.ByService()
+	// Loop over all the services by service name
+	for _, endpoints := range svcs {
+		if len(endpoints) < 1 {
+			continue
+		}
+
+		var svc *service.Service
+		// Find the first alive service and use that as the definition.
+		// If none are alive, we won't open the port.
+		for _, endpoint := range endpoints {
+			if endpoint.IsAlive() {
+				svc = endpoint
+				break
+			}
+		}
+
+		if svc == nil {
+			continue
+		}
+
+		// Loop over the ports and generate a named listener for
+		// each port.
+		for _, port := range svc.Ports {
+			// Only listen on ServicePorts
+			if port.ServicePort < 1 {
+				continue
+			}
+
+			listeners = append(listeners, s.EnvoyListenerFromService(svc, port.ServicePort))
+		}
+	}
+
+	return listeners
+}
+
+// Format an Envoy service name from our service name and port
+func SvcName(name string, port int64) string {
+	return fmt.Sprintf("%s%s%d", name, ServiceNameSeparator, port)
+}
+
+// Split an Enovy service name into our service name and port
+func SvcNameSplit(name string) (string, int64, error) {
+	parts := strings.Split(name, ServiceNameSeparator)
+	if len(parts) < 2 {
+		return "", -1, fmt.Errorf("%s", "Unable to split service name and port!")
+	}
+
+	svcName := parts[0]
+	svcPort, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return "", -1, fmt.Errorf("%s", "Unable to parse port!")
+	}
+
+	return svcName, svcPort, nil
+}
+
+// HttpMux returns a configured Gorilla mux to handle all the endpoints
+// for the Envoy API.
+func (s *EnvoyApi) HttpMux() http.Handler {
+	router := mux.NewRouter()
+	router.HandleFunc("/registration/{service}", wrap(s.registrationHandler)).Methods("GET")
+	router.HandleFunc("/clusters/{service_cluster}/{service_node}", wrap(s.clustersHandler)).Methods("GET")
+	router.HandleFunc("/clusters", wrap(s.clustersHandler)).Methods("GET")
+	router.HandleFunc("/listeners/{service_cluster}/{service_node}", wrap(s.listenersHandler)).Methods("GET")
+	router.HandleFunc("/listeners", wrap(s.listenersHandler)).Methods("GET")
+	router.HandleFunc("/{path}", s.optionsHandler).Methods("OPTIONS")
+
+	return router
+}

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -23,6 +23,8 @@ const (
 // This file implements the Envoy proxy V1 API on top of a Sidecar
 // service discovery cluster.
 
+// Envoy API definitions --------------------------------------------------
+
 // See https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds.html
 type EnvoyService struct {
 	IPAddress       string            `json:"ip_address"`
@@ -81,6 +83,7 @@ type EnvoyRoute struct {
 	HostRewrite string `json:"host_rewrite"`
 	Cluster     string `json:"cluster"`
 }
+// ------------------------------------------------------------------------
 
 type EnvoyApi struct {
 	list   *memberlist.Memberlist
@@ -290,6 +293,8 @@ func (s *EnvoyApi) EnvoyClustersFromState() []*EnvoyCluster {
 	return clusters
 }
 
+// EnvoyListenerFromService takes a Sidecar service and formats it into
+// the API format for an Envoy proxy listener (LDS API v1)
 func (s *EnvoyApi) EnvoyListenerFromService(svc *service.Service, port int64) *EnvoyListener {
 	apiName := SvcName(svc.Name, port)
 	// Holy indentation, Bat Man!

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -84,6 +84,7 @@ type EnvoyRoute struct {
 	HostRewrite string `json:"host_rewrite"`
 	Cluster     string `json:"cluster"`
 }
+
 // ------------------------------------------------------------------------
 
 type EnvoyApi struct {
@@ -182,9 +183,7 @@ func (s *EnvoyApi) clustersHandler(response http.ResponseWriter, req *http.Reque
 
 	result := struct {
 		Clusters []*EnvoyCluster `json:"clusters"`
-	}{
-		clusters,
-	}
+	}{clusters}
 
 	jsonBytes, err := json.MarshalIndent(&result, "", "  ")
 
@@ -211,9 +210,7 @@ func (s *EnvoyApi) listenersHandler(response http.ResponseWriter, req *http.Requ
 
 	result := struct {
 		Listeners []*EnvoyListener `json:"listeners"`
-	}{
-		listeners,
-	}
+	}{listeners}
 
 	jsonBytes, err := json.MarshalIndent(&result, "", "  ")
 	if err != nil {
@@ -325,7 +322,7 @@ func (s *EnvoyApi) EnvoyListenerFromService(svc *service.Service, port int64) *E
 	apiName := SvcName(svc.Name, port)
 	// Holy indentation, Bat Man!
 	return &EnvoyListener{
-		Name: apiName,
+		Name:    apiName,
 		Address: fmt.Sprintf("tcp://%s:%d", s.config.BindIP, port),
 		Filters: []*EnvoyFilter{
 			{

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -305,7 +305,7 @@ func (s *EnvoyApi) EnvoyListenerFromService(svc *service.Service, port int64) *E
 					StatPrefix: "ingress_http",
 					Filters: []*EnvoyFilter{
 						{
-							Name: "router",
+							Name:   "router",
 							Config: &EnvoyHttpFilterConfig{},
 						},
 					},

--- a/sidecarhttp/envoy_api_test.go
+++ b/sidecarhttp/envoy_api_test.go
@@ -1,0 +1,209 @@
+package sidecarhttp
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Nitro/sidecar/catalog"
+	"github.com/Nitro/sidecar/service"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	hostname = "chaucer"
+	state = catalog.NewServicesState()
+
+	baseTime = time.Now().UTC()
+
+	svcId = "deadbeef123"
+	svcId2 = "deadbeef456"
+	svcId3 = "deadbeef666"
+
+	svc = service.Service{
+		ID:       svcId,
+		Name:     "bocaccio",
+		Image:    "101deadbeef",
+		Created:  baseTime,
+		Hostname: hostname,
+		Updated:  baseTime,
+		Status:   service.ALIVE,
+		Ports: []service.Port{
+			{ IP: "127.0.0.1", Port: 9999, ServicePort: 10100 },
+		},
+	}
+
+	svc2 = service.Service{
+		ID:       svcId2,
+		Name:     "shakespeare",
+		Image:    "202deadbeef",
+		Created:  baseTime,
+		Hostname: hostname,
+		Updated:  baseTime,
+		Status:   service.UNHEALTHY,
+		Ports: []service.Port{
+			{ IP: "127.0.0.1", Port: 9000, ServicePort: 10111 },
+		},
+	}
+
+	svc3 = service.Service{
+		ID:       svcId3,
+		Name:     "dante",
+		Image:    "666deadbeef",
+		Created:  baseTime,
+		Hostname: hostname,
+		Updated:  baseTime,
+		Status:   service.ALIVE,
+	}
+)
+
+func Test_clustersHandler(t *testing.T) {
+	Convey("clustersHandler()", t, func() {
+		state.AddServiceEntry(svc)
+		state.AddServiceEntry(svc2)
+		state.AddServiceEntry(svc3)
+
+		req := httptest.NewRequest("GET", "/clusters", nil)
+		recorder := httptest.NewRecorder()
+
+		bindIP := "192.168.168.168"
+
+		api := &EnvoyApi{state: state, config: &HttpConfig{BindIP: bindIP}}
+
+		Convey("returns information for alive services", func() {
+			api.clustersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldContainSubstring, "bocaccio")
+		})
+
+		Convey("does not include unhealthy services", func() {
+			api.clustersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldNotContainSubstring, "shakespeare")
+		})
+
+		Convey("does not include services without a ServicePort", func() {
+			api.clustersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldNotContainSubstring, "dante")
+		})
+	})
+}
+
+func Test_registrationHandler(t *testing.T) {
+	Convey("registrationHandler()", t, func() {
+		state.AddServiceEntry(svc)
+		state.AddServiceEntry(svc2)
+		state.AddServiceEntry(svc3)
+
+		recorder := httptest.NewRecorder()
+
+		bindIP := "192.168.168.168"
+
+		api := &EnvoyApi{state: state, config: &HttpConfig{BindIP: bindIP}}
+
+		Convey("returns an error unless a service is provided", func() {
+			req := httptest.NewRequest("GET", "/registration/", nil)
+			api.registrationHandler(recorder, req, nil)
+			status, _, _ := getResult(recorder)
+
+			So(status, ShouldEqual, 404)
+		})
+
+		Convey("returns an error unless port is appended", func() {
+			req := httptest.NewRequest("GET", "/registration/", nil)
+			params := map[string]string{
+				"service":      "bocaccio",
+			}
+			api.registrationHandler(recorder, req, params)
+			status, _, _ := getResult(recorder)
+
+			So(status, ShouldEqual, 404)
+		})
+
+		Convey("returns information for alive services", func() {
+			req := httptest.NewRequest("GET", "/registration/bocaccio:10100", nil)
+			params := map[string]string{
+				"service":      "bocaccio:10100",
+			}
+			api.registrationHandler(recorder, req, params)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldContainSubstring, "bocaccio")
+		})
+
+		Convey("does not include services without a ServicePort", func() {
+			req := httptest.NewRequest("GET", "/registration/dante:12323", nil)
+			params := map[string]string{
+				"service":      "dante:12323",
+			}
+			api.registrationHandler(recorder, req, params)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 404)
+			So(body, ShouldContainSubstring, "no instances of dante")
+		})
+
+		Convey("does not include unhealthy services", func() {
+			req := httptest.NewRequest("GET", "/registration/shakespeare:10111", nil)
+			params := map[string]string{
+				"service":      "shakespeare:10111",
+			}
+			api.registrationHandler(recorder, req, params)
+			status, _, body := getResult(recorder)
+
+			So(body, ShouldContainSubstring, "no instances")
+			So(status, ShouldEqual, 404)
+		})
+	})
+}
+
+func Test_listenersHandler(t *testing.T) {
+	Convey("listenersHandler()", t, func() {
+		state.AddServiceEntry(svc)
+		state.AddServiceEntry(svc2)
+		state.AddServiceEntry(svc3)
+
+		recorder := httptest.NewRecorder()
+
+		bindIP := "192.168.168.168"
+
+		api := &EnvoyApi{state: state, config: &HttpConfig{BindIP: bindIP}}
+
+		Convey("returns listeners for alive services", func() {
+			req := httptest.NewRequest("GET", "/listeners/", nil)
+			api.listenersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldContainSubstring, "bocaccio")
+		})
+
+		Convey("doesn't return listeners for unhealthy services", func() {
+			req := httptest.NewRequest("GET", "/listeners/", nil)
+			api.listenersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+			So(body, ShouldNotContainSubstring, "shakespeare")
+		})
+	})
+}
+
+// getResult fetchs the status code, headers, and body from a recorder
+func getResult(recorder *httptest.ResponseRecorder) (code int, headers *http.Header, body string) {
+	resp := recorder.Result()
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	body = string(bodyBytes)
+
+	return resp.StatusCode, &resp.Header, body
+}


### PR DESCRIPTION
This is a first pass, dead simple implementation of the Envoy CDS, SDS, and LDS APIs on top of Sidecar. There are some hardcoded settings here and a bit of work to be done to make things more useful. But it fairly closely approximates the current HAproxy functionality on Envoy, with a few exceptions. I have tested it with [this Docker container build](https://gist.github.com/relistan/55a6f54bfc2b79d03eb0c8327c2aeb1c)