### PR TITLE
Fix concurrent map writes

### DIFF
--- a/discovery/docker_discovery.go
+++ b/discovery/docker_discovery.go
@@ -98,6 +98,9 @@ func (d *DockerDiscovery) inspectContainer(svc *service.Service) (*docker.Contai
 		return nil, err
 	}
 
+	d.Lock()
+	defer d.Unlock()
+
 	// Cache it for next time
 	d.containerCache[svc.ID] = container
 

--- a/docker/s6/services/.s6-svscan/crash
+++ b/docker/s6/services/.s6-svscan/crash
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "Container shutting down"
+echo "Container crashed"

--- a/docker/s6/services/.s6-svscan/finish
+++ b/docker/s6/services/.s6-svscan/finish
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Container shutting down"


### PR DESCRIPTION
Please note that the `containerCache` map is accessed without a lock guard from [`pruneContainerCache`](https://github.com/newrelic/sidecar/blob/62cd8e42c841c53758136fcd71f8f7b680e2826a/discovery/docker_discovery.go#L268) as well, but that seems safe, since this method is only called from [`getContainers `](https://github.com/newrelic/sidecar/blob/62cd8e42c841c53758136fcd71f8f7b680e2826a/discovery/docker_discovery.go#L231), which locks the RWMutex before invoking it.

I also added an s6 `finish` script to match [what we have in Lazyraster](https://github.com/Nitro/lazyraster/blob/master/docker/s6/services/.s6-svscan/finish) as discussed [here](https://github.com/newrelic/sidecar/issues/38#issuecomment-363581128).