### PR TITLE
Fix discovery

### DIFF
--- a/discovery/docker_discovery_test.go
+++ b/discovery/docker_discovery_test.go
@@ -153,7 +153,7 @@ func Test_DockerDiscovery(t *testing.T) {
 
 		Convey("inspectContainer()", func() {
 			Convey("looks in the cache first", func() {
-				disco.containerCache[svcId1] = &docker.Container{Path: "cached"}
+				disco.containerCache.Set(&service1, &docker.Container{Path: "cached"})
 				container, err := disco.inspectContainer(&service1)
 
 				So(err, ShouldBeNil)
@@ -186,15 +186,15 @@ func Test_DockerDiscovery(t *testing.T) {
 				liveContainers[svcId1] = true
 
 				// Cache some things
-				disco.containerCache[svcId1] = &docker.Container{Path: "cached"}
-				disco.containerCache[svcId2] = &docker.Container{Path: "cached"}
+				disco.containerCache.Set(&service1, &docker.Container{Path: "cached"})
+				disco.containerCache.Set(&service2, &docker.Container{Path: "cached"})
 
-				So(len(disco.containerCache), ShouldEqual, 2)
+				So(disco.containerCache.Len(), ShouldEqual, 2)
 
-				disco.pruneContainerCache(liveContainers)
+				disco.containerCache.Prune(liveContainers)
 
-				_, ok := disco.containerCache[svcId2] // Should be missing
-				So(ok, ShouldBeFalse)
+				container := disco.containerCache.Get(svcId2) // Should be missing
+				So(container, ShouldBeNil)
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -304,8 +304,8 @@ func main() {
 	trackingLooper := director.NewTimedLooper(
 		director.FOREVER, catalog.ALIVE_SLEEP_INTERVAL, nil,
 	)
-	discoLooper := director.NewTimedLooper(
-		director.FOREVER, discovery.SLEEP_INTERVAL, make(chan error),
+	discoLooper := director.NewFreeLooper(
+		director.FOREVER, make(chan error),
 	)
 	listenLooper := director.NewTimedLooper(
 		director.FOREVER, discovery.SLEEP_INTERVAL, make(chan error),


### PR DESCRIPTION
This extracts the container cache from the docker discovery system to a separate type. All access to the cache uses locks now, so we shouldn't see any more crashes related to concurrent map access for this module.