### PR TITLE
Fix Envoy API to obey the Envoy schema

### DIFF
--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -129,8 +129,7 @@ func (s *EnvoyApi) registrationHandler(response http.ResponseWriter, req *http.R
 		return
 	}
 
-	var instances []*EnvoyService
-
+	instances := make([]*EnvoyService, 0)
 	// Enter critical section
 	func() {
 		s.state.RLock()
@@ -144,13 +143,6 @@ func (s *EnvoyApi) registrationHandler(response http.ResponseWriter, req *http.R
 			}
 		})
 	}()
-
-	// Did we have any entries for this service in the catalog?
-	if len(instances) == 0 {
-		log.Debugf("Envoy Service '%s' has no instances!", name)
-		sendJsonError(response, 404, fmt.Sprintf("no instances of %s found", name))
-		return
-	}
 
 	clusterName := ""
 	if s.list != nil {
@@ -284,7 +276,7 @@ func (s *EnvoyApi) EnvoyServiceFromService(svc *service.Service, svcPort int64) 
 // EnvoyClustersFromState genenerates a set of Envoy API cluster
 // definitions from Sidecar state
 func (s *EnvoyApi) EnvoyClustersFromState() []*EnvoyCluster {
-	var clusters []*EnvoyCluster
+	clusters := make([]*EnvoyCluster, 0)
 
 	s.state.RLock()
 	defer s.state.RUnlock()
@@ -369,7 +361,7 @@ func (s *EnvoyApi) EnvoyListenerFromService(svc *service.Service, port int64) *E
 // EnvoyListenersFromState creates a set of Enovy API listener
 // definitions from all the ServicePorts in the Sidecar state.
 func (s *EnvoyApi) EnvoyListenersFromState() []*EnvoyListener {
-	var listeners []*EnvoyListener
+	listeners := make([]*EnvoyListener, 0)
 
 	s.state.RLock()
 	defer s.state.RUnlock()

--- a/sidecarhttp/envoy_api_test.go
+++ b/sidecarhttp/envoy_api_test.go
@@ -1,6 +1,7 @@
 package sidecarhttp
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -14,11 +15,11 @@ import (
 
 var (
 	hostname = "chaucer"
-	state = catalog.NewServicesState()
+	state    = catalog.NewServicesState()
 
 	baseTime = time.Now().UTC()
 
-	svcId = "deadbeef123"
+	svcId  = "deadbeef123"
 	svcId2 = "deadbeef456"
 	svcId3 = "deadbeef666"
 
@@ -31,7 +32,7 @@ var (
 		Updated:  baseTime,
 		Status:   service.ALIVE,
 		Ports: []service.Port{
-			{ IP: "127.0.0.1", Port: 9999, ServicePort: 10100 },
+			{IP: "127.0.0.1", Port: 9999, ServicePort: 10100},
 		},
 	}
 
@@ -44,7 +45,7 @@ var (
 		Updated:  baseTime,
 		Status:   service.UNHEALTHY,
 		Ports: []service.Port{
-			{ IP: "127.0.0.1", Port: 9000, ServicePort: 10111 },
+			{IP: "127.0.0.1", Port: 9000, ServicePort: 10111},
 		},
 	}
 
@@ -95,6 +96,20 @@ func Test_clustersHandler(t *testing.T) {
 			So(status, ShouldEqual, 200)
 			So(body, ShouldNotContainSubstring, "dante")
 		})
+
+		Convey("returns empty clusters for empty state", func() {
+			api := &EnvoyApi{state: catalog.NewServicesState(), config: &HttpConfig{BindIP: bindIP}}
+			api.clustersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+
+			var cdsResult CDSResult
+			err := json.Unmarshal([]byte(body), &cdsResult)
+			So(err, ShouldBeNil)
+			So(cdsResult.Clusters, ShouldNotBeNil)
+			So(cdsResult.Clusters, ShouldBeEmpty)
+		})
 	})
 }
 
@@ -121,7 +136,7 @@ func Test_registrationHandler(t *testing.T) {
 		Convey("returns an error unless port is appended", func() {
 			req := httptest.NewRequest("GET", "/registration/", nil)
 			params := map[string]string{
-				"service":      "bocaccio",
+				"service": "bocaccio",
 			}
 			api.registrationHandler(recorder, req, params)
 			status, _, _ := getResult(recorder)
@@ -132,7 +147,7 @@ func Test_registrationHandler(t *testing.T) {
 		Convey("returns information for alive services", func() {
 			req := httptest.NewRequest("GET", "/registration/bocaccio:10100", nil)
 			params := map[string]string{
-				"service":      "bocaccio:10100",
+				"service": "bocaccio:10100",
 			}
 			api.registrationHandler(recorder, req, params)
 			status, _, body := getResult(recorder)
@@ -144,25 +159,38 @@ func Test_registrationHandler(t *testing.T) {
 		Convey("does not include services without a ServicePort", func() {
 			req := httptest.NewRequest("GET", "/registration/dante:12323", nil)
 			params := map[string]string{
-				"service":      "dante:12323",
+				"service": "dante:12323",
 			}
 			api.registrationHandler(recorder, req, params)
 			status, _, body := getResult(recorder)
 
-			So(status, ShouldEqual, 404)
-			So(body, ShouldContainSubstring, "no instances of dante")
+			So(status, ShouldEqual, 200)
+
+			var sdsResult SDSResult
+			err := json.Unmarshal([]byte(body), &sdsResult)
+			So(err, ShouldBeNil)
+			So(sdsResult.Env, ShouldEqual, "")
+			So(sdsResult.Hosts, ShouldNotBeNil)
+			So(sdsResult.Hosts, ShouldBeEmpty)
+			So(sdsResult.Service, ShouldEqual, "dante:12323")
 		})
 
 		Convey("does not include unhealthy services", func() {
 			req := httptest.NewRequest("GET", "/registration/shakespeare:10111", nil)
 			params := map[string]string{
-				"service":      "shakespeare:10111",
+				"service": "shakespeare:10111",
 			}
 			api.registrationHandler(recorder, req, params)
 			status, _, body := getResult(recorder)
 
-			So(body, ShouldContainSubstring, "no instances")
-			So(status, ShouldEqual, 404)
+			So(status, ShouldEqual, 200)
+			var sdsResult SDSResult
+			err := json.Unmarshal([]byte(body), &sdsResult)
+			So(err, ShouldBeNil)
+			So(sdsResult.Env, ShouldEqual, "")
+			So(sdsResult.Hosts, ShouldNotBeNil)
+			So(sdsResult.Hosts, ShouldBeEmpty)
+			So(sdsResult.Service, ShouldEqual, "shakespeare:10111")
 		})
 	})
 }
@@ -178,9 +206,9 @@ func Test_listenersHandler(t *testing.T) {
 		bindIP := "192.168.168.168"
 
 		api := &EnvoyApi{state: state, config: &HttpConfig{BindIP: bindIP}}
+		req := httptest.NewRequest("GET", "/listeners/", nil)
 
 		Convey("returns listeners for alive services", func() {
-			req := httptest.NewRequest("GET", "/listeners/", nil)
 			api.listenersHandler(recorder, req, nil)
 			status, _, body := getResult(recorder)
 
@@ -189,12 +217,25 @@ func Test_listenersHandler(t *testing.T) {
 		})
 
 		Convey("doesn't return listeners for unhealthy services", func() {
-			req := httptest.NewRequest("GET", "/listeners/", nil)
 			api.listenersHandler(recorder, req, nil)
 			status, _, body := getResult(recorder)
 
 			So(status, ShouldEqual, 200)
 			So(body, ShouldNotContainSubstring, "shakespeare")
+		})
+
+		Convey("returns empty listeners for empty state", func() {
+			api := &EnvoyApi{state: catalog.NewServicesState(), config: &HttpConfig{BindIP: bindIP}}
+			api.listenersHandler(recorder, req, nil)
+			status, _, body := getResult(recorder)
+
+			So(status, ShouldEqual, 200)
+
+			var ldsResult LDSResult
+			err := json.Unmarshal([]byte(body), &ldsResult)
+			So(err, ShouldBeNil)
+			So(ldsResult.Listeners, ShouldNotBeNil)
+			So(ldsResult.Listeners, ShouldBeEmpty)
 		})
 	})
 }


### PR DESCRIPTION
With these changes, Envoy will be able to update a service if all of its instances are taken offline. It should also handle empty LDS and CDS replies gracefully.

Here are the errors reported by Envoy which I have addressed through these changes:
```
[2018-06-29 16:20:35.125][87][debug][router] source/common/router/router.cc:248] [C0][S17692232238502726859] cluster 'sidecar-lds' match for URL '/v1/listeners/nitro-dev/ODBM0NEFD59L'
...
[2018-06-29 16:20:35.126][87][warning][upstream] source/server/lds_subscription.cc:68] lds: fetch failure: JSON at lines 1-1 does not conform to schema.
 Invalid schema: #/properties/listeners
 Schema violation: type
 Offending document key: #/listeners
```
and
```
[2018-06-29 16:20:40.007][87][debug][router] source/common/router/router.cc:248] [C0][S18127002071380746196] cluster 'sidecar-cds' match for URL '/v1/clusters/nitro-dev/ODBM0NEFD59L'
...
[2018-06-29 16:20:40.009][87][warning][upstream] source/common/upstream/cds_subscription.cc:68] cds: fetch failure: JSON at lines 1-1 does not conform to schema.
 Invalid schema: #/properties/clusters
 Schema violation: type
 Offending document key: #/clusters
```
and
```
[2018-06-29 16:42:17.854][85][debug][router] source/common/router/router.cc:248] [C0][S11484281113936301517] cluster 'sidecar-sds' match for URL '/v1/registration/whoami:9080'
...
[2018-06-29 16:42:17.855][85][warning][upstream] source/common/upstream/sds_subscription.cc:88] sds parsing error: JSON at lines 1-1 does not conform to schema.
 Invalid schema: #/properties/hosts
 Schema violation: type
 Offending document key: #/hosts
```