### PR TITLE
Check errors in docker_discovery.go

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -8,14 +8,14 @@ import (
 )
 
 const (
-	SLEEP_INTERVAL = 1 * time.Second
+	DefaultSleepInterval = 1 * time.Second
 )
 
 // A ChangeListener is a service that will receive service change events
 // over the HTTP interface.
 type ChangeListener struct {
-	Name string    // Name to be represented in the Listeners list
-	Url  string    // Url of the service to send events to
+	Name string // Name to be represented in the Listeners list
+	Url  string // Url of the service to send events to
 }
 
 // A Discoverer is responsible for finding services that we care

--- a/discovery/docker_discovery.go
+++ b/discovery/docker_discovery.go
@@ -44,7 +44,7 @@ func NewDockerDiscovery(endpoint string, svcNamer ServiceNamer, ip string) *Dock
 		containerCache: NewContainerCache(),
 		serviceNamer:   svcNamer,
 		advertiseIp:    ip,
-		sleepInterval:  SLEEP_INTERVAL,
+		sleepInterval:  DefaultSleepInterval,
 	}
 
 	// Default to our own method for returning this

--- a/discovery/docker_discovery.go
+++ b/discovery/docker_discovery.go
@@ -278,29 +278,37 @@ func (d *DockerDiscovery) getContainers() {
 	d.containerCache.Prune(containerMap)
 }
 
-func (d *DockerDiscovery) manageConnection(quit chan bool) {
+func (d *DockerDiscovery) configureDockerConnection() DockerClient {
 	client, err := d.ClientProvider()
 	if err != nil {
-		log.Errorf("Error when creating Docker client: %s\n", err.Error())
-		return
+		log.Errorf("Error creating Docker client: %s", err)
+		return nil
 	}
-	client.AddEventListener(d.events)
+
+	err = client.AddEventListener(d.events)
+	if err != nil {
+		log.Errorf("Error adding Docker client event listener: %s", err)
+		return nil
+	}
+
+	return client
+}
+
+func (d *DockerDiscovery) manageConnection(quit chan bool) {
+	client := d.configureDockerConnection()
 
 	// Health check the connection and set it back up when it goes away.
 	for {
-
-		err := client.Ping()
-		if err != nil {
+		// Is the client connected?
+		if client == nil || client.Ping() != nil {
 			log.Warn("Lost connection to Docker, re-connecting")
-			client.RemoveEventListener(d.events)
+			if client != nil {
+				// Swallow errors since we're overwriting the client anyway
+				_ = client.RemoveEventListener(d.events)
+			}
 			d.events = make(chan *docker.APIEvents) // RemoveEventListener closes it
 
-			client, err = docker.NewClient(d.endpoint)
-			if err == nil {
-				client.AddEventListener(d.events)
-			} else {
-				log.Error("Can't reconnect to Docker!")
-			}
+			client = d.configureDockerConnection()
 		}
 
 		select {
@@ -309,6 +317,7 @@ func (d *DockerDiscovery) manageConnection(quit chan bool) {
 		default:
 		}
 
+		// Sleep a bit before attempting to reconnect
 		time.Sleep(SLEEP_INTERVAL)
 	}
 }

--- a/discovery/static_discovery_test.go
+++ b/discovery/static_discovery_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Nitro/sidecar/service"
 	"github.com/relistan/go-director"
@@ -73,10 +74,13 @@ func Test_Services(t *testing.T) {
 		})
 
 		Convey("Updates the current timestamp each time", func() {
-			services := disco.Services()
-			services2 := disco.Services()
+			s := disco.Services()
+			firstUpdate := s[0].Updated
+			time.Sleep(1 * time.Millisecond)
+			s = disco.Services()
+			secondUpdate := s[0].Updated
 
-			So(services[0].Updated.Before(services2[0].Updated), ShouldBeTrue)
+			So(firstUpdate.Before(secondUpdate), ShouldBeTrue)
 		})
 	})
 }
@@ -93,11 +97,11 @@ func Test_Listeners(t *testing.T) {
 
 		Convey("Returns all listeners extracted from Targets", func() {
 			tgt1 := &Target{
-				Service: service.Service{Name: "beowulf", ID: "asdf"},
+				Service:    service.Service{Name: "beowulf", ID: "asdf"},
 				ListenPort: 10000,
 			}
 			tgt2 := &Target{
-				Service: service.Service{Name: "hrothgar", ID: "abba"},
+				Service:    service.Service{Name: "hrothgar", ID: "abba"},
 				ListenPort: 11000,
 			}
 			disco.Targets = []*Target{tgt1, tgt2}
@@ -105,12 +109,12 @@ func Test_Listeners(t *testing.T) {
 			listeners := disco.Listeners()
 
 			expected0 := ChangeListener{
-				Name:"Service(beowulf-asdf)",
-				Url:"http://" + disco.Hostname + ":10000/sidecar/update",
+				Name: "Service(beowulf-asdf)",
+				Url:  "http://" + disco.Hostname + ":10000/sidecar/update",
 			}
 			expected1 := ChangeListener{
-				Name:"Service(hrothgar-abba)",
-				Url:"http://" + disco.Hostname + ":11000/sidecar/update",
+				Name: "Service(hrothgar-abba)",
+				Url:  "http://" + disco.Hostname + ":11000/sidecar/update",
 			}
 
 			So(len(listeners), ShouldEqual, 2)

--- a/main.go
+++ b/main.go
@@ -307,10 +307,10 @@ func main() {
 		director.FOREVER, catalog.ALIVE_SLEEP_INTERVAL, nil,
 	)
 	discoLooper := director.NewTimedLooper(
-		director.FOREVER, discovery.SLEEP_INTERVAL, make(chan error),
+		director.FOREVER, discovery.DefaultSleepInterval, make(chan error),
 	)
 	listenLooper := director.NewTimedLooper(
-		director.FOREVER, discovery.SLEEP_INTERVAL, make(chan error),
+		director.FOREVER, discovery.DefaultSleepInterval, make(chan error),
 	)
 	healthWatchLooper := director.NewTimedLooper(
 		director.FOREVER, healthy.WATCH_INTERVAL, make(chan error),

--- a/services_delegate.go
+++ b/services_delegate.go
@@ -7,9 +7,9 @@ import (
 	"github.com/Nitro/memberlist"
 	"github.com/Nitro/sidecar/catalog"
 	"github.com/Nitro/sidecar/service"
-	log "github.com/sirupsen/logrus"
 	"github.com/armon/go-metrics"
 	"github.com/pquerna/ffjson/ffjson"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -143,7 +143,7 @@ func (d *servicesDelegate) GetBroadcasts(overhead, limit int) [][]byte {
 }
 
 func (d *servicesDelegate) LocalState(join bool) []byte {
-	log.Debugf("LocalState(): %b", join)
+	log.Debugf("LocalState(): %t", join)
 	d.state.RLock()
 	defer d.state.RUnlock()
 	return d.state.Encode()
@@ -200,9 +200,9 @@ func (d *servicesDelegate) packPacket(broadcasts [][]byte, limit int, overhead i
 		total += len(message) + overhead
 	}
 
-	if lastItem < 0 && len(broadcasts) > 0{
+	if lastItem < 0 && len(broadcasts) > 0 {
 		// Don't warn on startup... it's fairly normal
-		gracePeriod := time.Now().UTC().Add(0-(5*time.Second))
+		gracePeriod := time.Now().UTC().Add(0 - (5 * time.Second))
 		if d.StartedAt.Before(gracePeriod) {
 			log.Warnf("All messages were too long to fit! No broadcasts!")
 		}


### PR DESCRIPTION
Looks like we're missing some error checks in there and we should keep on retrying to connect even if `d.ClientProvider()` fails the first time.

Also, the `for` loop in `manageConnection` was calling `docker.NewClient(d.endpoint)` instead of `d.ClientProvider()`, which seems wrong to me, because `d.ClientProvider()` resolves to `d.getDockerClient()`, which is able to call `docker.NewClientFromEnv()`, in case `d.endpoint == ""`.

I also fixed a flaky test in `static_discovery`.

TODO:
- [x] Figure out why it sometimes crashes when restarting Docker with `panic: send on closed channel` at `vendor/github.com/fsouza/go-dockerclient/event.go:344`