### PR TITLE
Enable golangci lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.12.x
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ services:
 
 before_install:
   - sudo apt-get install -y nodejs
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
 
 script:
+  - golangci-lint run
   - go test -v --timeout 30s ./... && (CGO_ENABLED=0 GOOS=linux go build -ldflags '-d')
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "${TRAVIS_GO_VERSION::3}" == "${PRODUCTION_GO_VERSION}" ]; then
       echo "Building container gonitro/sidecar:${TRAVIS_COMMIT::7}" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,11 @@ sudo: required
 services:
   - docker
 
-install:
-  # For some reason Travis seems to need this installed explicitly
-  - go get github.com/sirupsen/logrus
-
 before_install:
   - sudo apt-get install -y nodejs
 
 script:
-  - go test -v --timeout 30s `go list ./... | grep -v /vendor/` && (CGO_ENABLED=0 GOOS=linux go build -ldflags '-d')
+  - go test -v --timeout 30s ./... && (CGO_ENABLED=0 GOOS=linux go build -ldflags '-d')
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "${TRAVIS_GO_VERSION::3}" == "${PRODUCTION_GO_VERSION}" ]; then
       echo "Building container gonitro/sidecar:${TRAVIS_COMMIT::7}" &&
       cd ui && npm install && cd .. &&

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -220,12 +220,12 @@
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
-  digest = "1:d8ead22d381cfed54d53be7d935eb0f9f2b75889a4fb595802844b805dc13b87"
+  digest = "1:387bc9c583e744c448f77cd90d0551634fc682d0af505d2fa955243a73f37c24"
   name = "github.com/jtolds/gls"
   packages = ["."]
   pruneopts = ""
-  revision = "77f18212c9c7edc9bd6a33d383a7b545ce62f064"
-  version = "v4.2.1"
+  revision = "b4936e06046bbecbb94cae9c18127ebe510a2cb9"
+  version = "v4.20"
 
 [[projects]]
   digest = "1:b60a24f942c7031ece6c48bcab0b683c7d3d6aa9fd17e21459d9ae604da258fa"
@@ -326,7 +326,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:fbf54e9f8cf26ea8e66dc1e0cc615663efa95af8c8d806125ff7f7bb7311b9e0"
+  digest = "1:87378f85dd64a5c51cf71495cabd384b250fb12be2b6a26486fb2e3b723a07ee"
   name = "github.com/smartystreets/assertions"
   packages = [
     ".",
@@ -334,11 +334,10 @@
     "internal/oglematchers",
   ]
   pruneopts = ""
-  revision = "ff1918e1e5a13a74014644ae7c1e0ba2f791364d"
-  version = "1.8.0"
+  revision = "980c5ac6f3acb6ce1cfe13160e49188807174fbe"
 
 [[projects]]
-  digest = "1:dd808f0f1628ff85a1b54424d3e6a61c54a87353d5063b9b5c82ad360f0346d5"
+  digest = "1:1f0ec82e0f5b72526f0abbe520a13ceb95e7ec05386ef261228813f272a0c05e"
   name = "github.com/smartystreets/goconvey"
   packages = [
     "convey",
@@ -346,8 +345,7 @@
     "convey/reporting",
   ]
   pruneopts = ""
-  revision = "9e8dc3f972df6c8fcc0375ef492c24d0bb204857"
-  version = "1.6.3"
+  revision = "200a235640ff2643e3126834b67f3e93df76640a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
 
 [[constraint]]
   name = "github.com/smartystreets/goconvey"
-  version = "1.6.3"
+  revision = "200a235640ff2643e3126834b67f3e93df76640a"
 
 [[constraint]]
   name = "gopkg.in/alecthomas/kingpin.v2"

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ $ go run *.go --cluster-ip <boostrap_host>
 ```
 
 You always need to supply at least one IP address or hostname with the
-`--cluster-ip` argument. If are running solo, or are the first member, this can
-be your own hostname. You may specify the argument multiple times to have
+`--cluster-ip` argument (or via the `SIDECAR_SEEDS` environment variable).
+If are running solo, or are the first member, this can be your own
+hostname. You may specify the argument multiple times to have
 multiple hosts. It is recommended to use more than one when possible.
 
 Note: `--cluster-ip` will overwrite the values passed into the `SIDECAR_SEEDS` environment variable.

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -575,7 +575,7 @@ func (state *ServicesState) BroadcastTombstones(fn func() []service.Service, loo
 
 		tombstones = append(tombstones, otherTombstones...)
 
-		if tombstones != nil && len(tombstones) > 0 {
+		if len(tombstones) > 0 {
 			state.SendServices(
 				tombstones,
 				director.NewTimedLooper(TOMBSTONE_COUNT, state.tombstoneRetransmit, nil),

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -486,13 +486,14 @@ func Test_Listeners(t *testing.T) {
 			So(len(state.listeners), ShouldEqual, 1)
 
 			err := state.RemoveListener("listener1")
-			So(len(state.listeners), ShouldEqual, 0)
 			So(err, ShouldBeNil)
+			So(len(state.listeners), ShouldEqual, 0)
 		})
 
-		Convey("Removing a listener that doesn't exist returns an error", func() {
-			err := state.RemoveListener("foo")
+		Convey("Removing non-existent listeners returns an error", func() {
+			err := state.RemoveListener("dummyListener")
 			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "no listener found with the name")
 		})
 
 		Convey("A major state change event notifies all listeners", func() {

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -271,7 +271,8 @@ func Test_TrackingAndBroadcasting(t *testing.T) {
 			looper := director.NewFreeLooper(5, make(chan error))
 			state.Broadcasts = make(chan [][]byte, 5)
 			state.SendServices(services, looper)
-			looper.Wait()
+			err := looper.Wait()
+			So(err, ShouldBeNil)
 
 			So(len(state.Broadcasts), ShouldEqual, 5)
 		})
@@ -280,7 +281,8 @@ func Test_TrackingAndBroadcasting(t *testing.T) {
 			looper := director.NewFreeLooper(1, make(chan error))
 			go state.TrackNewServices(containerFn, looper)
 			state.ProcessServiceMsgs(director.NewFreeLooper(2, nil))
-			looper.Wait()
+			err := looper.Wait()
+			So(err, ShouldBeNil)
 
 			So(state.Servers[hostname].Services[svcId1], ShouldNotBeNil)
 			So(state.Servers[hostname].Services[svcId2], ShouldNotBeNil)
@@ -328,7 +330,9 @@ func Test_TrackingAndBroadcasting(t *testing.T) {
 			service1.Tombstone()
 			service2.Tombstone()
 			go state.SendServices([]service.Service{service1, service2}, looper)
-			looper.Wait()
+
+			err := looper.Wait()
+			So(err, ShouldBeNil)
 
 			// First go-round
 			broadcasts := <-state.Broadcasts
@@ -639,7 +643,8 @@ func Test_DecodeStream(t *testing.T) {
 		}
 
 		buf := bytes.NewBufferString(string(jsonBytes))
-		DecodeStream(buf, mockCallback)
+		err = DecodeStream(buf, mockCallback)
+		So(err, ShouldBeNil)
 		So(compareMap["api"][0].Hostname, ShouldEqual, "some-aws-host")
 		So(compareMap["api"][0].Status, ShouldEqual, 1)
 	})

--- a/catalog/url_listener.go
+++ b/catalog/url_listener.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -34,7 +34,7 @@ type UrlListener struct {
 // A StateChangedEvent is sent to UrlListeners when a significant
 // event has changed the ServicesState.
 type StateChangedEvent struct {
-	State       ServicesState
+	State       *ServicesState
 	ChangeEvent ChangeEvent
 }
 
@@ -122,7 +122,7 @@ func (u *UrlListener) Watch(state *ServicesState) {
 
 			state.RLock()
 			event := StateChangedEvent{
-				State:       *state,
+				State:       state,
 				ChangeEvent: changedServiceEvent,
 			}
 

--- a/catalog/url_listener_test.go
+++ b/catalog/url_listener_test.go
@@ -80,8 +80,9 @@ func Test_Listen(t *testing.T) {
 			listener.eventChannel <- ChangeEvent{}
 			listener.Retries = 0
 			listener.Watch(state)
-			listener.looper.Wait()
+			err := listener.looper.Wait()
 
+			So(err, ShouldBeNil)
 			So(len(errors), ShouldEqual, 0)
 		})
 	})

--- a/cli.go
+++ b/cli.go
@@ -28,13 +28,14 @@ func parseCommandLine() *CliOpts {
 	app := kingpin.New("sidecar", "")
 
 	opts.AdvertiseIP = app.Flag("advertise-ip", "The address to advertise to the cluster").Short('a').String()
-	opts.ClusterIPs = app.Flag("cluster-ip", "The cluster seed addresses").Required().Short('c').NoEnvar().Strings()
+	opts.ClusterIPs = app.Flag("cluster-ip", "The cluster seed addresses").Short('c').NoEnvar().Strings()
 	opts.ClusterName = app.Flag("cluster-name", "The cluster we're part of").Short('n').String()
 	opts.CpuProfile = app.Flag("cpuprofile", "Enable CPU profiling").Short('p').Bool()
 	opts.Discover = app.Flag("discover", "Method of discovery").Short('d').NoEnvar().Strings()
 	opts.LoggingLevel = app.Flag("logging-level", "Set the logging level").Short('l').String()
 
-	app.Parse(os.Args[1:])
+	_, err := app.Parse(os.Args[1:])
+	exitWithError(err, "Failed to parse CLI opts")
 
 	return &opts
 }

--- a/cli.go
+++ b/cli.go
@@ -8,12 +8,12 @@ import (
 )
 
 type CliOpts struct {
-	AdvertiseIP    *string
-	ClusterIPs     *[]string
-	ClusterName    *string
-	CpuProfile     *bool
-	Discover       *[]string
-	LoggingLevel   *string
+	AdvertiseIP  *string
+	ClusterIPs   *[]string
+	ClusterName  *string
+	CpuProfile   *bool
+	Discover     *[]string
+	LoggingLevel *string
 }
 
 func exitWithError(err error, message string) {

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -210,15 +210,15 @@ func (h *HAproxy) swallowSignals() {
 		}
 	}()
 
-	signal.Notify(sigChan, syscall.SIGSTOP, syscall.SIGTSTP, syscall.SIGTTIN, syscall.SIGTTOU)
+	signal.Notify(sigChan, syscall.SIGTSTP, syscall.SIGTTIN, syscall.SIGTTOU)
 }
 
 // ResetSignals unhooks our signal handler from the signals the sub-commands
 // initiate. This is potentially destructive if other places in the program have
-// hooked to the same signals! Affected signals are SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU.
+// hooked to the same signals! Affected signals are SIGTSTP, SIGTTIN, SIGTTOU.
 func (h *HAproxy) ResetSignals() {
 	h.sigLock.Lock()
-	signal.Reset(syscall.SIGSTOP, syscall.SIGTSTP, syscall.SIGTTIN, syscall.SIGTTOU)
+	signal.Reset(syscall.SIGTSTP, syscall.SIGTTIN, syscall.SIGTTOU)
 	select {
 	case h.sigStopChan <- struct{}{}: // nothing
 	default:

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -286,7 +286,10 @@ func (h *HAproxy) Watch(state *catalog.ServicesState) {
 		}
 	}
 
-	state.RemoveListener(h.Name())
+	err := state.RemoveListener(h.Name())
+	if err != nil {
+		log.Warnf("Failed to remove HAProxy listener: %s", err)
+	}
 }
 
 // Write out the the HAproxy config and reload the service.

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -184,7 +184,10 @@ func (h *HAproxy) WriteConfig(state *catalog.ServicesState, output io.Writer) er
 	}
 
 	// This is the potentially slowest bit, do it outside the critical section
-	io.Copy(output, buf)
+	_, err = io.Copy(output, buf)
+	if err != nil {
+		return fmt.Errorf("Error writing template '%s': %s", h.Template, err.Error())
+	}
 
 	return nil
 }

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -16,7 +16,6 @@ import (
 
 var hostname1 = "indomitable"
 var hostname2 = "indefatigable"
-var hostname3 = "invincible"
 
 func Test_HAproxy(t *testing.T) {
 	Convey("End-to-end testing HAproxy functionality", t, func() {
@@ -30,9 +29,17 @@ func Test_HAproxy(t *testing.T) {
 		ip := "127.0.0.1"
 		ip3 := "127.0.0.3"
 
-		ports1 := []service.Port{{"tcp", 10450, 8080, ip}, {"tcp", 10020, 9000, ip}}
-		ports2 := []service.Port{{"tcp", 9999, 8090, ip3}}
-		ports3 := []service.Port{{"tcp", 32763, 8080, ip3}, {"tcp", 10020, 9000, ip3}}
+		ports1 := []service.Port{
+			{Type: "tcp", Port: 10450, ServicePort: 8080, IP: ip},
+			{Type: "tcp", Port: 10020, ServicePort: 9000, IP: ip},
+		}
+		ports2 := []service.Port{
+			{Type: "tcp", Port: 9999, ServicePort: 8090, IP: ip3},
+		}
+		ports3 := []service.Port{
+			{Type: "tcp", Port: 32763, ServicePort: 8080, IP: ip3},
+			{Type: "tcp", Port: 10020, ServicePort: 9000, IP: ip3},
+		}
 
 		services := []service.Service{
 			{
@@ -130,7 +137,9 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: "titanic",
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
+				Ports: []service.Port{
+					{Type: "tcp", Port: 666, ServicePort: 6666, IP: "127.0.0.1"},
+				},
 			}
 
 			// It had 1 before
@@ -178,7 +187,9 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNHEALTHY,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
+				Ports: []service.Port{
+					{Type: "tcp", Port: 666, ServicePort: 6666, IP: "127.0.0.1"},
+				},
 			}
 			badSvc2 := service.Service{
 				ID:       "0000bad00001",
@@ -187,13 +198,16 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNKNOWN,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{{"tcp", 666, 6666, "127.0.0.1"}},
+				Ports: []service.Port{
+					{Type: "tcp", Port: 666, ServicePort: 6666, IP: "127.0.0.1"},
+				},
 			}
 			state.AddServiceEntry(badSvc)
 			state.AddServiceEntry(badSvc2)
 
 			buf := bytes.NewBuffer(make([]byte, 0, 2048))
-			proxy.WriteConfig(state, buf)
+			err := proxy.WriteConfig(state, buf)
+			So(err, ShouldBeNil)
 
 			output := buf.Bytes()
 			// Look for a few things we should NOT see
@@ -249,7 +263,9 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: hostname2,
 				Updated:  newTime,
-				Ports:    []service.Port{{"tcp", 1337, 8090, "127.0.0.1"}},
+				Ports: []service.Port{
+					{Type: "tcp", Port: 1337, ServicePort: 8090, IP: "127.0.0.1"},
+				},
 			}
 		OUTER:
 			for {

--- a/healthy/service_bridge.go
+++ b/healthy/service_bridge.go
@@ -117,7 +117,11 @@ func (m *Monitor) templateCheckArgs(check *Check, svc *service.Service) string {
 	}
 
 	var output bytes.Buffer
-	t.Execute(&output, svc)
+	err = t.Execute(&output, svc)
+	if err != nil {
+		log.Errorf("Unable to execute template: '%s'", check.Args)
+		return check.Args
+	}
 
 	return output.String()
 }

--- a/healthy/service_bridge_test.go
+++ b/healthy/service_bridge_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Nitro/sidecar/discovery"
 	"github.com/Nitro/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/Nitro/sidecar/discovery"
 )
 
 var hostname string = "indefatigable"
@@ -137,7 +137,10 @@ func Test_ServicesBridge(t *testing.T) {
 		Convey("Responds to changes in a list of services", func() {
 			So(len(monitor.Checks), ShouldEqual, 4)
 
-			ports := []service.Port{{"udp", 11234, 8080, "127.0.0.1"}, {"tcp", 1234, 8081, "127.0.0.1"}}
+			ports := []service.Port{
+				{Type: "udp", Port: 11234, ServicePort: 8080, IP: "127.0.0.1"},
+				{Type: "tcp", Port: 1234, ServicePort: 8081, IP: "127.0.0.1"},
+			}
 			svc := service.Service{ID: "babbacabba", Name: "testing-12312312", Ports: ports}
 			svcList := []service.Service{svc}
 
@@ -165,8 +168,8 @@ func Test_CheckForService(t *testing.T) {
 	Convey("When building a default check", t, func() {
 		svcId1 := "deadbeef123"
 		ports := []service.Port{
-			{"udp", 11234, 8080, "127.0.0.1"},
-			{"tcp", 1234, 8081, "127.0.0.1"},
+			{Type: "udp", Port: 11234, ServicePort: 8080, IP: "127.0.0.1"},
+			{Type: "tcp", Port: 1234, ServicePort: 8081, IP: "127.0.0.1"},
 		}
 		service1 := service.Service{ID: svcId1, Hostname: hostname, Ports: ports}
 

--- a/logging_bridge_test.go
+++ b/logging_bridge_test.go
@@ -11,21 +11,24 @@ func Test_LoggingBridge(t *testing.T) {
 		bridge := LoggingBridge{testing: true}
 
 		Convey("Properly splits apart and re-levels log messages", func() {
-			bridge.Write([]byte("2016/06/24 11:45:33 [DEBUG] memberlist: TCP connection from=172.16.106.1:59598"))
+			_, err := bridge.Write([]byte("2016/06/24 11:45:33 [DEBUG] memberlist: TCP connection from=172.16.106.1:59598"))
+			So(err, ShouldBeNil)
 
 			So(string(bridge.lastLevel), ShouldEqual, "[DEBUG]")
 			So(string(bridge.lastMessage), ShouldEqual, "memberlist: TCP connection from=172.16.106.1:59598")
 
-			bridge.Write([]byte("2016/06/24 11:45:33 [WARN] memberlist: Something something"))
+			_, err = bridge.Write([]byte("2016/06/24 11:45:33 [WARN] memberlist: Something something"))
+			So(err, ShouldBeNil)
 
 			So(string(bridge.lastLevel), ShouldEqual, "[WARN]")
 			So(string(bridge.lastMessage), ShouldEqual, "memberlist: Something something")
 		})
 
 		Convey("Handles writes that have more than one message", func() {
-			bridge.Write(
+			_, err := bridge.Write(
 				[]byte("2016/06/24 11:45:33 [DEBUG] memberlist: TCP connection from=172.16.106.1:59598\nasdf"),
 			)
+			So(err, ShouldBeNil)
 
 			So(string(bridge.lastMessage), ShouldEqual, "memberlist: TCP connection from=172.16.106.1:59598")
 		})

--- a/main.go
+++ b/main.go
@@ -189,7 +189,8 @@ func configureCpuProfiler(opts *CliOpts) {
 	if *opts.CpuProfile {
 		profilerFile, err := os.Create("sidecar.cpu.prof")
 		exitWithError(err, "Can't write profiling file")
-		pprof.StartCPUProfile(profilerFile)
+		err = pprof.StartCPUProfile(profilerFile)
+		exitWithError(err, "Can't start the CPU profiler")
 		log.Debug("Profiling!")
 	}
 }
@@ -367,7 +368,8 @@ func main() {
 	})
 
 	if !config.HAproxy.Disable {
-		proxy.WriteAndReload(state)
+		err := proxy.WriteAndReload(state)
+		exitWithError(err, "Failed to reload HAProxy config")
 	}
 
 	select {}

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -22,7 +22,10 @@ func UpdateHandler(response http.ResponseWriter, req *http.Request, rcvr *Receiv
 	if err != nil {
 		message, _ := json.Marshal(ApiErrors{[]string{err.Error()}})
 		response.WriteHeader(http.StatusInternalServerError)
-		response.Write(message)
+		_, err := response.Write(message)
+		if err != nil {
+			log.Errorf("Error replying to client when failed to read the request body: %s", err)
+		}
 		return
 	}
 
@@ -31,7 +34,10 @@ func UpdateHandler(response http.ResponseWriter, req *http.Request, rcvr *Receiv
 	if err != nil {
 		message, _ := json.Marshal(ApiErrors{[]string{err.Error()}})
 		response.WriteHeader(http.StatusInternalServerError)
-		response.Write(message)
+		_, err := response.Write(message)
+		if err != nil {
+			log.Errorf("Error replying to client when failed to unmarshal the request JSON: %s", err)
+		}
 		return
 	}
 

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -39,7 +39,7 @@ func UpdateHandler(response http.ResponseWriter, req *http.Request, rcvr *Receiv
 	defer rcvr.StateLock.Unlock()
 
 	if rcvr.CurrentState == nil || rcvr.CurrentState.LastChanged.Before(evt.State.LastChanged) {
-		rcvr.CurrentState = &evt.State
+		rcvr.CurrentState = evt.State
 		rcvr.LastSvcChanged = &evt.ChangeEvent.Service
 
 		if ShouldNotify(evt.ChangeEvent.PreviousStatus, evt.ChangeEvent.Service.Status) {

--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -78,7 +78,7 @@ func Test_updateHandler(t *testing.T) {
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
-				State: *evtState,
+				State: evtState,
 				ChangeEvent: catalog.ChangeEvent{
 					Service: service.Service{
 						ID:      "10101010101",
@@ -112,7 +112,7 @@ func Test_updateHandler(t *testing.T) {
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
-				State: *evtState,
+				State: evtState,
 				ChangeEvent: catalog.ChangeEvent{
 					Service: service.Service{
 						Name:    "nobody-wants-this",
@@ -141,7 +141,7 @@ func Test_updateHandler(t *testing.T) {
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
-				State: *evtState,
+				State: evtState,
 				ChangeEvent: catalog.ChangeEvent{
 					Service: service.Service{
 						Name:    "nobody-wants-this",
@@ -172,7 +172,7 @@ func Test_updateHandler(t *testing.T) {
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
-				State: *evtState,
+				State: evtState,
 				ChangeEvent: catalog.ChangeEvent{
 					Service: service.Service{
 						Name:    "subscribed-service",
@@ -203,7 +203,7 @@ func Test_updateHandler(t *testing.T) {
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
-				State: *evtState,
+				State: evtState,
 				ChangeEvent: catalog.ChangeEvent{
 					Service: service.Service{
 						ID:      "10101010101",

--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -73,8 +73,7 @@ func Test_updateHandler(t *testing.T) {
 		Convey("updates the state and enqueues an update", func() {
 			startTime := rcvr.CurrentState.LastChanged
 
-			var evtState *catalog.ServicesState
-			evtState = deepcopy.Copy(state).(*catalog.ServicesState)
+			evtState := deepcopy.Copy(state).(*catalog.ServicesState)
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
@@ -107,8 +106,7 @@ func Test_updateHandler(t *testing.T) {
 		})
 
 		Convey("enqueus all updates if no Subscriptions are provided", func() {
-			var evtState *catalog.ServicesState
-			evtState = deepcopy.Copy(state).(*catalog.ServicesState)
+			evtState := deepcopy.Copy(state).(*catalog.ServicesState)
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
@@ -136,8 +134,7 @@ func Test_updateHandler(t *testing.T) {
 		})
 
 		Convey("does not enqueue updates if the service is not subscribed to", func() {
-			var evtState *catalog.ServicesState
-			evtState = deepcopy.Copy(state).(*catalog.ServicesState)
+			evtState := deepcopy.Copy(state).(*catalog.ServicesState)
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
@@ -167,8 +164,7 @@ func Test_updateHandler(t *testing.T) {
 		})
 
 		Convey("enqueues updates if the service is subscribed to", func() {
-			var evtState *catalog.ServicesState
-			evtState = deepcopy.Copy(state).(*catalog.ServicesState)
+			evtState := deepcopy.Copy(state).(*catalog.ServicesState)
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{
@@ -198,8 +194,7 @@ func Test_updateHandler(t *testing.T) {
 		})
 
 		Convey("a copy of the state is passed to the OnUpdate func", func() {
-			var evtState *catalog.ServicesState
-			evtState = deepcopy.Copy(state).(*catalog.ServicesState)
+			evtState := deepcopy.Copy(state).(*catalog.ServicesState)
 			evtState.LastChanged = time.Now().UTC()
 
 			change := catalog.StateChangedEvent{

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -145,8 +145,7 @@ func (rcvr *Receiver) ProcessUpdates() {
 			// Copy the state while locked so we don't have it change
 			// under us while writing and we don't hold onto the lock the
 			// whole time we're writing to disk (e.g. in haproxy-api).
-			var tmpState *catalog.ServicesState
-			tmpState = deepcopy.Copy(rcvr.CurrentState).(*catalog.ServicesState)
+			tmpState := deepcopy.Copy(rcvr.CurrentState).(*catalog.ServicesState)
 			rcvr.StateLock.Unlock()
 
 			rcvr.OnUpdate(tmpState)

--- a/service/service.go
+++ b/service/service.go
@@ -184,7 +184,7 @@ func buildPortFor(port *docker.APIPort, container *docker.APIContainers, ip stri
 		if err != nil {
 			log.Errorf("Error converting label value for %s to integer: %s",
 				svcPortLabel,
-				err.Error(),
+				err,
 			)
 			return returnPort
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -1,4 +1,5 @@
 package service
+
 //go:generate ffjson $GOFILE
 
 import (
@@ -9,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Nitro/sidecar/output"
-	log "github.com/sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -110,11 +111,16 @@ func (svc *Service) Version() string {
 	return parts[0]
 }
 
-func Decode(data []byte) *Service {
+// Decode decodes the input data JSON into a *Service. If it fails, it returns
+// a non-nil error
+func Decode(data []byte) (*Service, error) {
 	var svc Service
-	svc.UnmarshalJSON(data)
+	err := svc.UnmarshalJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode service JSON: %s", err)
+	}
 
-	return &svc
+	return &svc, nil
 }
 
 // Format an APIContainers struct into a more compact struct we

--- a/services_delegate.go
+++ b/services_delegate.go
@@ -45,9 +45,9 @@ func NewServicesDelegate(state *catalog.ServicesState) *servicesDelegate {
 func (d *servicesDelegate) Start() {
 	go func() {
 		for message := range d.notifications {
-			entry := service.Decode(message)
-			if entry == nil {
-				log.Errorf("NotifyMsg(): error decoding!")
+			entry, err := service.Decode(message)
+			if err != nil {
+				log.Errorf("Start(): error decoding message: %s", err)
 				continue
 			}
 			d.state.ServiceMsgs <- *entry

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -259,12 +259,11 @@ func (s *EnvoyApi) EnvoyServiceFromService(svc *service.Service, svcPort int64) 
 			// NOT recommended... this is very slow. Useful in dev modes where you
 			// need to resolve to a different IP address only.
 			if s.config.UseHostnames {
-				var err error
-				address, err = lookupHost(svc.Hostname)
-				if err != nil {
+				if host, err := lookupHost(svc.Hostname); err == nil {
+					address = host
+				} else {
 					log.Warnf("Unable to resolve %s, using IP address", svc.Hostname)
 				}
-				address = port.IP
 			}
 
 			return &EnvoyService{

--- a/sidecarhttp/envoy_api.go
+++ b/sidecarhttp/envoy_api.go
@@ -108,7 +108,6 @@ type EnvoyApi struct {
 func (s *EnvoyApi) optionsHandler(response http.ResponseWriter, req *http.Request) {
 	response.Header().Set("Access-Control-Allow-Origin", "*")
 	response.Header().Set("Access-Control-Allow-Methods", "GET")
-	return
 }
 
 type SDSResult struct {
@@ -167,12 +166,15 @@ func (s *EnvoyApi) registrationHandler(response http.ResponseWriter, req *http.R
 	jsonBytes, err := result.MarshalJSON()
 	defer ffjson.Pool(jsonBytes)
 	if err != nil {
-		log.Errorf("Error marshaling state in registrationHandler: %s", err.Error())
+		log.Errorf("Error marshaling state in registrationHandler: %s", err)
 		sendJsonError(response, 500, "Internal server error")
 		return
 	}
 
-	response.Write(jsonBytes)
+	_, err = response.Write(jsonBytes)
+	if err != nil {
+		log.Errorf("Error writing registration response to client: %s", err)
+	}
 }
 
 type CDSResult struct {
@@ -201,7 +203,10 @@ func (s *EnvoyApi) clustersHandler(response http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	response.Write(jsonBytes)
+	_, err = response.Write(jsonBytes)
+	if err != nil {
+		log.Errorf("Error writing clusters response to client: %s", err)
+	}
 }
 
 type LDSResult struct {
@@ -229,7 +234,10 @@ func (s *EnvoyApi) listenersHandler(response http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	response.Write(jsonBytes)
+	_, err = response.Write(jsonBytes)
+	if err != nil {
+		log.Errorf("Error writing listeners response to client: %s", err)
+	}
 }
 
 // lookupHost does a vv slow lookup of the DNS host for a service. Totally

--- a/sidecarhttp/http.go
+++ b/sidecarhttp/http.go
@@ -32,12 +32,16 @@ func serversHandler(response http.ResponseWriter, req *http.Request, list *membe
 	state.RLock()
 	defer state.RUnlock()
 
-	response.Write(
+	_, err := response.Write(
 		[]byte(`
  			<head>
  			<meta http-equiv="refresh" content="4">
  			</head>
 	    	<pre>` + state.Format(list) + "</pre>"))
+
+	if err != nil {
+		log.Errorf("Error writing servers response to client: %s", err)
+	}
 }
 
 type Member struct {

--- a/sidecarhttp/http_api.go
+++ b/sidecarhttp/http_api.go
@@ -63,7 +63,12 @@ func (s *SidecarApi) watchHandler(response http.ResponseWriter, req *http.Reques
 	// Let's subscribe to state change events
 	// AddListener and RemoveListener are thread safe
 	s.state.AddListener(listener)
-	defer s.state.RemoveListener(listener.Name())
+	defer func() {
+		err := s.state.RemoveListener(listener.Name())
+		if err != nil {
+			log.Warnf("Failed to remove HTTP listener: %s", err)
+		}
+	}()
 
 	byService := true
 	if req.URL.Query().Get("by_service") == "false" {

--- a/sidecarhttp/http_api.go
+++ b/sidecarhttp/http_api.go
@@ -60,9 +60,6 @@ func (s *SidecarApi) watchHandler(response http.ResponseWriter, req *http.Reques
 
 	listener := NewHttpListener()
 
-	// Find out when the http connection closed so we can stop
-	notify := response.(http.CloseNotifier).CloseNotify()
-
 	// Let's subscribe to state change events
 	// AddListener and RemoveListener are thread safe
 	s.state.AddListener(listener)
@@ -111,7 +108,8 @@ func (s *SidecarApi) watchHandler(response http.ResponseWriter, req *http.Reques
 	// Watch for further updates on the channel
 	for {
 		select {
-		case <-notify:
+		// Find out when the http connection was closed so we can stop
+		case <-req.Context().Done():
 			return
 
 		case <-listener.Chan():

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -51,22 +51,56 @@ func addStackTag(tag uint, context_call func()) {
 
 // these private methods are named this horrendous name so gopherjs support
 // is easier. it shouldn't add any runtime cost in non-js builds.
+
+//go:noinline
 func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
 
 func _m(tag_remainder uint, cb func()) {

--- a/vendor/github.com/smartystreets/assertions/.travis.yml
+++ b/vendor/github.com/smartystreets/assertions/.travis.yml
@@ -2,11 +2,10 @@ language: go
 
 go:
   - 1.x
-  - master
 
 install:
   - go get -t ./...
 
-script: go test -v
+script: go test ./... -v
 
 sudo: false

--- a/vendor/github.com/smartystreets/assertions/README.md
+++ b/vendor/github.com/smartystreets/assertions/README.md
@@ -8,6 +8,8 @@ referenced in goconvey's `convey` package
 (github.com/smartystreets/gunit) for use with the So(...) method. They can also
 be used in traditional Go test functions and even in applications.
 
+https://smartystreets.com
+
 Many of the assertions lean heavily on work done by Aaron Jacobs in his
 excellent oglematchers library. (https://github.com/jacobsa/oglematchers) The
 ShouldResemble assertion leans heavily on work done by Daniel Jacques in his
@@ -25,7 +27,7 @@ the assertions in this package from the convey package JSON results are very
 helpful and can be rendered in a DIFF view. In that case, this function will be
 called with a true value to enable the JSON serialization. By default, the
 assertions in this package will not serializer a JSON result, making standalone
-ussage more convenient.
+usage more convenient.
 
 #### func  ShouldAlmostEqual
 
@@ -78,6 +80,15 @@ func ShouldBeEmpty(actual interface{}, expected ...interface{}) string
 ShouldBeEmpty receives a single parameter (actual) and determines whether or not
 calling len(actual) would return `0`. It obeys the rules specified by the len
 function for determining length: http://golang.org/pkg/builtin/#len
+
+#### func  ShouldBeError
+
+```go
+func ShouldBeError(actual interface{}, expected ...interface{}) string
+```
+ShouldBeError asserts that the first argument implements the error interface. It
+also compares the first argument against the second argument if provided (which
+must be an error message string or another error value).
 
 #### func  ShouldBeFalse
 
@@ -187,7 +198,19 @@ ends with the second.
 ```go
 func ShouldEqual(actual interface{}, expected ...interface{}) string
 ```
-ShouldEqual receives exactly two parameters and does an equality check.
+ShouldEqual receives exactly two parameters and does an equality check using the
+following semantics: 1. If the expected and actual values implement an Equal
+method in the form `func (this T) Equal(that T) bool` then call the method. If
+true, they are equal. 2. The expected and actual values are judged equal or not
+by oglematchers.Equals.
+
+#### func  ShouldEqualJSON
+
+```go
+func ShouldEqualJSON(actual interface{}, expected ...interface{}) string
+```
+ShouldEqualJSON receives exactly two parameters and does an equality check by
+marshalling to JSON
 
 #### func  ShouldEqualTrimSpace
 
@@ -349,6 +372,14 @@ func ShouldNotBeNil(actual interface{}, expected ...interface{}) string
 ```
 ShouldNotBeNil receives a single parameter and ensures that it is not nil.
 
+#### func  ShouldNotBeZeroValue
+
+```go
+func ShouldNotBeZeroValue(actual interface{}, expected ...interface{}) string
+```
+ShouldBeZeroValue receives a single parameter and ensures that it is NOT the Go
+equivalent of the default value, or "zero" value.
+
 #### func  ShouldNotContain
 
 ```go
@@ -386,7 +417,8 @@ does not end with the second.
 ```go
 func ShouldNotEqual(actual interface{}, expected ...interface{}) string
 ```
-ShouldNotEqual receives exactly two parameters and does an inequality check.
+ShouldNotEqual receives exactly two parameters and does an inequality check. See
+ShouldEqual for details on how equality is determined.
 
 #### func  ShouldNotHappenOnOrBetween
 
@@ -520,6 +552,10 @@ Example:
     if ok, message := So(x, ShouldBeGreaterThan, y); !ok {
          log.Println(message)
     }
+
+For an alternative implementation of So (that provides more flexible return
+options) see the `So` function in the package at
+github.com/smartystreets/assertions/assert.
 
 #### type Assertion
 

--- a/vendor/github.com/smartystreets/assertions/assert/assert.go
+++ b/vendor/github.com/smartystreets/assertions/assert/assert.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-
-	"github.com/smartystreets/logging"
 )
 
 // Result contains a single assertion failure as an error.
@@ -20,7 +18,7 @@ type Result struct {
 	err        error
 
 	stdout io.Writer
-	logger *logging.Logger
+	logger *logger
 }
 
 // So is a convenience function (as opposed to an inconvenience function?)

--- a/vendor/github.com/smartystreets/assertions/assert/assert_failed_test.go
+++ b/vendor/github.com/smartystreets/assertions/assert/assert_failed_test.go
@@ -3,25 +3,23 @@ package assert
 import (
 	"testing"
 
+	"github.com/smartystreets/assertions/internal/unit"
 	"github.com/smartystreets/assertions/should"
-	"github.com/smartystreets/gunit"
-	"github.com/smartystreets/logging"
 )
 
 func TestFailedResultFixture(t *testing.T) {
-	gunit.Run(new(FailedResultFixture), t)
+	unit.Run(new(FailedResultFixture), t)
 }
 
 type FailedResultFixture struct {
-	*gunit.Fixture
+	*unit.Fixture
 
 	result *Result
 }
 
 func (this *FailedResultFixture) Setup() {
 	this.result = So(1, should.Equal, 2)
-	this.result.logger = logging.Capture()
-	this.result.logger.SetPrefix("")
+	this.result.logger = capture()
 	this.result.stdout = this.result.logger.Log
 }
 
@@ -36,8 +34,8 @@ func (this *FailedResultFixture) TestQueryFunctions() {
 	this.So(this.result.Passed(), should.BeFalse)
 	this.So(this.result.logger.Log.Len(), should.Equal, 0)
 
-	this.result.logger.Println(this.result.String())
-	this.result.logger.Println(this.result.Error())
+	this.result.logger.Print(this.result.String())
+	this.result.logger.Print(this.result.Error())
 	this.assertLogMessageContents()
 }
 

--- a/vendor/github.com/smartystreets/assertions/assert/assert_passed_test.go
+++ b/vendor/github.com/smartystreets/assertions/assert/assert_passed_test.go
@@ -3,24 +3,23 @@ package assert
 import (
 	"testing"
 
+	"github.com/smartystreets/assertions/internal/unit"
 	"github.com/smartystreets/assertions/should"
-	"github.com/smartystreets/gunit"
-	"github.com/smartystreets/logging"
 )
 
 func TestPassedResultFixture(t *testing.T) {
-	gunit.Run(new(PassedResultFixture), t)
+	unit.Run(new(PassedResultFixture), t)
 }
 
 type PassedResultFixture struct {
-	*gunit.Fixture
+	*unit.Fixture
 
 	result *Result
 }
 
 func (this *PassedResultFixture) Setup() {
 	this.result = So(1, should.Equal, 1)
-	this.result.logger = logging.Capture()
+	this.result.logger = capture()
 	this.result.stdout = this.result.logger.Log
 }
 

--- a/vendor/github.com/smartystreets/assertions/assert/logger.go
+++ b/vendor/github.com/smartystreets/assertions/assert/logger.go
@@ -1,0 +1,76 @@
+package assert
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+)
+
+// logger is meant be included as a pointer field on a struct. Leaving the
+// instance as a nil reference will cause any calls on the *logger to forward
+// to the corresponding functions from the standard log package. This is meant
+// to be the behavior in production. In testing, set the field to a non-nil
+// instance of a *logger to record log statements for later inspection.
+type logger struct {
+	*log.Logger
+
+	Log   *bytes.Buffer
+	Calls int
+}
+
+// capture creates a new *logger instance with an internal buffer. The prefix
+// and flags default to the values of log.Prefix() and log.Flags(), respectively.
+// This function is meant to be called from test code. See the godoc for the
+// logger struct for details.
+func capture() *logger {
+	out := new(bytes.Buffer)
+	inner := log.New(out, log.Prefix(), log.Flags())
+	inner.SetPrefix("")
+	return &logger{
+		Log:    out,
+		Logger: inner,
+	}
+}
+
+// Fatal -> log.Fatal (except in testing it uses log.Print)
+func (this *logger) Fatal(v ...interface{}) {
+	if this == nil {
+		this.Output(3, fmt.Sprint(v...))
+		os.Exit(1)
+	} else {
+		this.Calls++
+		this.Logger.Print(v...)
+	}
+}
+
+// Panic -> log.Panic
+func (this *logger) Panic(v ...interface{}) {
+	if this == nil {
+		s := fmt.Sprint(v...)
+		this.Output(3, s)
+		panic(s)
+	} else {
+		this.Calls++
+		this.Logger.Panic(v...)
+	}
+}
+
+// Print -> log.Print
+func (this *logger) Print(v ...interface{}) {
+	if this == nil {
+		this.Output(3, fmt.Sprint(v...))
+	} else {
+		this.Calls++
+		this.Logger.Print(v...)
+	}
+}
+
+// Output -> log.Output
+func (this *logger) Output(calldepth int, s string) error {
+	if this == nil {
+		return log.Output(calldepth, s)
+	}
+	this.Calls++
+	return this.Logger.Output(calldepth, s)
+}

--- a/vendor/github.com/smartystreets/assertions/collections.go
+++ b/vendor/github.com/smartystreets/assertions/collections.go
@@ -227,7 +227,7 @@ func ShouldHaveLength(actual interface{}, expected ...interface{}) string {
 		if int64(value.Len()) == expectedLen {
 			return success
 		} else {
-			return fmt.Sprintf(shouldHaveHadLength, actual, value.Len(), expectedLen)
+			return fmt.Sprintf(shouldHaveHadLength, expectedLen, value.Len(), actual)
 		}
 	case reflect.Ptr:
 		elem := value.Elem()
@@ -236,7 +236,7 @@ func ShouldHaveLength(actual interface{}, expected ...interface{}) string {
 			if int64(elem.Len()) == expectedLen {
 				return success
 			} else {
-				return fmt.Sprintf(shouldHaveHadLength, actual, elem.Len(), expectedLen)
+				return fmt.Sprintf(shouldHaveHadLength, expectedLen, elem.Len(), actual)
 			}
 		}
 	}

--- a/vendor/github.com/smartystreets/assertions/collections_test.go
+++ b/vendor/github.com/smartystreets/assertions/collections_test.go
@@ -145,16 +145,31 @@ func (this *AssertionsFixture) TestShouldHaveLength() {
 	this.fail(so([]string{}, ShouldHaveLength, 1, 2), "This assertion requires exactly 1 comparison values (you provided 2).")
 	this.fail(so([]string{}, ShouldHaveLength, -10), "You must provide a valid positive integer (was -10)!")
 
-	this.fail(so([]int{}, ShouldHaveLength, 1), "Expected [] (length: 0) to have length equal to '1', but it wasn't!")             // empty slice
-	this.fail(so([]interface{}{}, ShouldHaveLength, 1), "Expected [] (length: 0) to have length equal to '1', but it wasn't!")     // empty slice
-	this.fail(so(map[string]int{}, ShouldHaveLength, 1), "Expected map[] (length: 0) to have length equal to '1', but it wasn't!") // empty map
-	this.fail(so("", ShouldHaveLength, 1), "Expected  (length: 0) to have length equal to '1', but it wasn't!")                    // empty string
-	this.fail(so(&[]int{}, ShouldHaveLength, 1), "Expected &[] (length: 0) to have length equal to '1', but it wasn't!")           // pointer to empty slice
-	this.fail(so(&[0]int{}, ShouldHaveLength, 1), "Expected &[] (length: 0) to have length equal to '1', but it wasn't!")          // pointer to empty array
-	c := make(chan int, 0)                                                                                                         // non-empty channel
-	this.fail(so(c, ShouldHaveLength, 1), fmt.Sprintf("Expected %+v (length: 0) to have length equal to '1', but it wasn't!", c))
+	this.fail(so([]int{}, ShouldHaveLength, 1), // empty slice
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: []")
+
+	this.fail(so([]interface{}{}, ShouldHaveLength, 1), // empty slice
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: []")
+
+	this.fail(so(map[string]int{}, ShouldHaveLength, 1), // empty map
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: map[]")
+
+	this.fail(so("", ShouldHaveLength, 1), // empty string
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: ")
+
+	this.fail(so(&[]int{}, ShouldHaveLength, 1), // pointer to empty slice
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: &[]")
+
+	this.fail(so(&[0]int{}, ShouldHaveLength, 1), // pointer to empty array
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: &[]")
+
+	c := make(chan int, 0) // non-empty channel
+	this.fail(so(c, ShouldHaveLength, 1), fmt.Sprintf(
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: %+v", c))
+
 	c = make(chan int) // empty channel
-	this.fail(so(c, ShouldHaveLength, 1), fmt.Sprintf("Expected %+v (length: 0) to have length equal to '1', but it wasn't!", c))
+	this.fail(so(c, ShouldHaveLength, 1), fmt.Sprintf(
+		"Expected collection to have length equal to [1], but it's length was [0] instead! contents: %+v", c))
 
 	this.pass(so([]int{1}, ShouldHaveLength, 1))                // non-empty slice
 	this.pass(so([]interface{}{1}, ShouldHaveLength, 1))        // non-empty slice
@@ -167,5 +182,4 @@ func (this *AssertionsFixture) TestShouldHaveLength() {
 	time.Sleep(time.Millisecond)
 	this.pass(so(c, ShouldHaveLength, 1))
 	this.pass(so(c, ShouldHaveLength, uint(1)))
-
 }

--- a/vendor/github.com/smartystreets/assertions/doc.go
+++ b/vendor/github.com/smartystreets/assertions/doc.go
@@ -5,6 +5,8 @@
 // They can also be used in traditional Go test functions and even in
 // applications.
 //
+// https://smartystreets.com
+//
 // Many of the assertions lean heavily on work done by Aaron Jacobs in his excellent oglematchers library.
 // (https://github.com/jacobsa/oglematchers)
 // The ShouldResemble assertion leans heavily on work done by Daniel Jacques in his very helpful go-render library.

--- a/vendor/github.com/smartystreets/assertions/equal_method_test.go
+++ b/vendor/github.com/smartystreets/assertions/equal_method_test.go
@@ -3,15 +3,15 @@ package assertions
 import (
 	"testing"
 
-	"github.com/smartystreets/gunit"
+	"github.com/smartystreets/assertions/internal/unit"
 )
 
 func TestEqualityFixture(t *testing.T) {
-	gunit.Run(new(EqualityFixture), t)
+	unit.Run(new(EqualityFixture), t)
 }
 
 type EqualityFixture struct {
-	*gunit.Fixture
+	*unit.Fixture
 }
 
 func (this *EqualityFixture) TestNilNil() {

--- a/vendor/github.com/smartystreets/assertions/equality_test.go
+++ b/vendor/github.com/smartystreets/assertions/equality_test.go
@@ -157,6 +157,45 @@ func (this *AssertionsFixture) TestShouldResemble() {
 	this.fail(so(IntAlias(42), ShouldResemble, 42), `42|42|Expected: '42' Actual: 'assertions.IntAlias(42)' (Should resemble)!`)
 }
 
+func (this *AssertionsFixture) TestShouldEqualJSON() {
+	this.fail(so("hi", ShouldEqualJSON), "This assertion requires exactly 1 comparison values (you provided 0).")
+	this.fail(so("hi", ShouldEqualJSON, "hi", "hi"), "This assertion requires exactly 1 comparison values (you provided 2).")
+
+	// basic identity of keys/values
+	this.pass(so(`{"my":"val"}`, ShouldEqualJSON, `{"my":"val"}`))
+	this.fail(so(`{"my":"val"}`, ShouldEqualJSON, `{"your":"val"}`),
+		`{"your":"val"}|{"my":"val"}|Expected: '{"your":"val"}' Actual: '{"my":"val"}' (Should be equal)`)
+
+	// out of order values causes comparison failure:
+	this.pass(so(`{"key0":"val0","key1":"val1"}`, ShouldEqualJSON, `{"key1":"val1","key0":"val0"}`))
+	this.fail(so(`{"key0":"val0","key1":"val1"}`, ShouldEqualJSON, `{"key1":"val0","key0":"val0"}`),
+		`{"key0":"val0","key1":"val0"}|{"key0":"val0","key1":"val1"}|Expected: '{"key0":"val0","key1":"val0"}' Actual: '{"key0":"val0","key1":"val1"}' (Should be equal)`)
+
+	// missing values causes comparison failure:
+	this.fail(so(
+		`{"key0":"val0","key1":"val1"}`,
+		ShouldEqualJSON,
+		`{"key1":"val0"}`),
+		`{"key1":"val0"}|{"key0":"val0","key1":"val1"}|Expected: '{"key1":"val0"}' Actual: '{"key0":"val0","key1":"val1"}' (Should be equal)`)
+
+	// whitespace shouldn't interfere with comparison:
+	this.pass(so("\n{ \"my\"  :   \"val\"\n}", ShouldEqualJSON, `{"my":"val"}`))
+
+	// Invalid JSON for either actual or expected value is invalid:
+	this.fail(so("{}", ShouldEqualJSON, ""), "Expected value not valid JSON: unexpected end of JSON input")
+	this.fail(so("", ShouldEqualJSON, "{}"), "Actual value not valid JSON: unexpected end of JSON input")
+
+	// Support JSON array:
+	this.pass(so("[]", ShouldEqualJSON, "[]"))
+
+	// Support any JSON value:
+	this.pass(so(`"hi"`, ShouldEqualJSON, `"hi"`))
+	this.pass(so(`42`, ShouldEqualJSON, `42`))
+	this.pass(so(`true`, ShouldEqualJSON, `true`))
+	this.pass(so(`false`, ShouldEqualJSON, `false`))
+	this.pass(so(`null`, ShouldEqualJSON, `null`))
+}
+
 func (this *AssertionsFixture) TestShouldNotResemble() {
 	this.fail(so(Thing1{"hi"}, ShouldNotResemble), "This assertion requires exactly 1 comparison values (you provided 0).")
 	this.fail(so(Thing1{"hi"}, ShouldNotResemble, Thing1{"hi"}, Thing1{"hi"}), "This assertion requires exactly 1 comparison values (you provided 2).")
@@ -294,4 +333,21 @@ func (this *AssertionsFixture) TestShouldBeZeroValue() {
 	this.pass(so(false, ShouldBeZeroValue))
 	this.pass(so("", ShouldBeZeroValue))
 	this.pass(so(struct{}{}, ShouldBeZeroValue))
+}
+
+func (this *AssertionsFixture) TestShouldNotBeZeroValue() {
+	this.fail(so(0, ShouldNotBeZeroValue, 1, 2, 3), "This assertion requires exactly 0 comparison values (you provided 3).")
+	this.fail(so(false, ShouldNotBeZeroValue, true), "This assertion requires exactly 0 comparison values (you provided 1).")
+
+	this.fail(so(0, ShouldNotBeZeroValue), "0|0|'0' should NOT have been the zero value")
+	this.fail(so(false, ShouldNotBeZeroValue), "false|false|'false' should NOT have been the zero value")
+	this.fail(so("", ShouldNotBeZeroValue), "||'' should NOT have been the zero value")
+	this.fail(so(struct{}{}, ShouldNotBeZeroValue), "{}|{}|'{}' should NOT have been the zero value")
+
+	this.pass(so(1, ShouldNotBeZeroValue))
+	this.pass(so(true, ShouldNotBeZeroValue))
+	this.pass(so("123", ShouldNotBeZeroValue))
+	this.pass(so(" ", ShouldNotBeZeroValue))
+	this.pass(so([]string{"Nonempty"}, ShouldNotBeZeroValue))
+	this.pass(so(struct{ a string }{a: "asdf"}, ShouldNotBeZeroValue))
 }

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/render/render.go
@@ -143,20 +143,24 @@ func (s *traverseState) render(buf *bytes.Buffer, ptrs int, v reflect.Value, imp
 		if !implicit {
 			writeType(buf, ptrs, vt)
 		}
-		structAnon := vt.Name() == ""
 		buf.WriteRune('{')
-		for i := 0; i < vt.NumField(); i++ {
-			if i > 0 {
-				buf.WriteString(", ")
-			}
-			anon := structAnon && isAnon(vt.Field(i).Type)
+		if rendered, ok := renderTime(v); ok {
+			buf.WriteString(rendered)
+		} else {
+			structAnon := vt.Name() == ""
+			for i := 0; i < vt.NumField(); i++ {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+				anon := structAnon && isAnon(vt.Field(i).Type)
 
-			if !anon {
-				buf.WriteString(vt.Field(i).Name)
-				buf.WriteRune(':')
-			}
+				if !anon {
+					buf.WriteString(vt.Field(i).Name)
+					buf.WriteRune(':')
+				}
 
-			s.render(buf, 0, v.Field(i), anon)
+				s.render(buf, 0, v.Field(i), anon)
+			}
 		}
 		buf.WriteRune('}')
 

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/render/render_test.go
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/render/render_test.go
@@ -1,0 +1,281 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func init() {
+	// For testing purposes, pointers will render as "PTR" so that they are
+	// deterministic.
+	renderPointer = func(buf *bytes.Buffer, p uintptr) {
+		buf.WriteString("PTR")
+	}
+}
+
+func assertRendersLike(t *testing.T, name string, v interface{}, exp string) {
+	act := Render(v)
+	if act != exp {
+		_, _, line, _ := runtime.Caller(1)
+		t.Errorf("On line #%d, [%s] did not match expectations:\nExpected: %s\nActual  : %s\n", line, name, exp, act)
+	}
+}
+
+func TestRenderList(t *testing.T) {
+	t.Parallel()
+
+	// Note that we make some of the fields exportable. This is to avoid a fun case
+	// where the first reflect.Value has a read-only bit set, but follow-on values
+	// do not, so recursion tests are off by one.
+	type testStruct struct {
+		Name string
+		I    interface{}
+
+		m string
+	}
+
+	type myStringSlice []string
+	type myStringMap map[string]string
+	type myIntType int
+	type myStringType string
+	type myTypeWithTime struct{ Public, private time.Time }
+
+	var date = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	populatedTimes := myTypeWithTime{date, date}
+	zeroTimes := myTypeWithTime{}
+
+	s0 := "string0"
+	s0P := &s0
+	mit := myIntType(42)
+	stringer := fmt.Stringer(nil)
+
+	for i, tc := range []struct {
+		a interface{}
+		s string
+	}{
+		{nil, `nil`},
+		{make(chan int), `(chan int)(PTR)`},
+		{&stringer, `(*fmt.Stringer)(nil)`},
+		{123, `123`},
+		{"hello", `"hello"`},
+		{(*testStruct)(nil), `(*render.testStruct)(nil)`},
+		{(**testStruct)(nil), `(**render.testStruct)(nil)`},
+		{[]***testStruct(nil), `[]***render.testStruct(nil)`},
+		{testStruct{Name: "foo", I: &testStruct{Name: "baz"}},
+			`render.testStruct{Name:"foo", I:(*render.testStruct){Name:"baz", I:interface{}(nil), m:""}, m:""}`},
+		{[]byte(nil), `[]uint8(nil)`},
+		{[]byte{}, `[]uint8{}`},
+		{map[string]string(nil), `map[string]string(nil)`},
+		{[]*testStruct{
+			{Name: "foo"},
+			{Name: "bar"},
+		}, `[]*render.testStruct{(*render.testStruct){Name:"foo", I:interface{}(nil), m:""}, ` +
+			`(*render.testStruct){Name:"bar", I:interface{}(nil), m:""}}`},
+		{myStringSlice{"foo", "bar"}, `render.myStringSlice{"foo", "bar"}`},
+		{myStringMap{"foo": "bar"}, `render.myStringMap{"foo":"bar"}`},
+		{myIntType(12), `render.myIntType(12)`},
+		{&mit, `(*render.myIntType)(42)`},
+		{myStringType("foo"), `render.myStringType("foo")`},
+		{zeroTimes, `render.myTypeWithTime{Public:time.Time{0}, private:time.Time{wall:0, ext:0, loc:(*time.Location)(nil)}}`},
+		{populatedTimes, `render.myTypeWithTime{Public:time.Time{2000-01-01 00:00:00 +0000 UTC}, private:time.Time{wall:0, ext:63082281600, loc:(*time.Location)(nil)}}`},
+		{struct {
+			a int
+			b string
+		}{123, "foo"}, `struct { a int; b string }{123, "foo"}`},
+		{[]string{"foo", "foo", "bar", "baz", "qux", "qux"},
+			`[]string{"foo", "foo", "bar", "baz", "qux", "qux"}`},
+		{[...]int{1, 2, 3}, `[3]int{1, 2, 3}`},
+		{map[string]bool{
+			"foo": true,
+			"bar": false,
+		}, `map[string]bool{"bar":false, "foo":true}`},
+		{map[int]string{1: "foo", 2: "bar"}, `map[int]string{1:"foo", 2:"bar"}`},
+		{uint32(1337), `1337`},
+		{3.14, `3.14`},
+		{complex(3, 0.14), `(3+0.14i)`},
+		{&s0, `(*string)("string0")`},
+		{&s0P, `(**string)("string0")`},
+		{[]interface{}{nil, 1, 2, nil}, `[]interface{}{interface{}(nil), 1, 2, interface{}(nil)}`},
+	} {
+		assertRendersLike(t, fmt.Sprintf("Input #%d", i), tc.a, tc.s)
+	}
+}
+
+func TestRenderRecursiveStruct(t *testing.T) {
+	type testStruct struct {
+		Name string
+		I    interface{}
+	}
+
+	s := &testStruct{
+		Name: "recursive",
+	}
+	s.I = s
+
+	assertRendersLike(t, "Recursive struct", s,
+		`(*render.testStruct){Name:"recursive", I:<REC(*render.testStruct)>}`)
+}
+
+func TestRenderRecursiveArray(t *testing.T) {
+	a := [2]interface{}{}
+	a[0] = &a
+	a[1] = &a
+
+	assertRendersLike(t, "Recursive array", &a,
+		`(*[2]interface{}){<REC(*[2]interface{})>, <REC(*[2]interface{})>}`)
+}
+
+func TestRenderRecursiveMap(t *testing.T) {
+	m := map[string]interface{}{}
+	foo := "foo"
+	m["foo"] = m
+	m["bar"] = [](*string){&foo, &foo}
+	v := []map[string]interface{}{m, m}
+
+	assertRendersLike(t, "Recursive map", v,
+		`[]map[string]interface{}{{`+
+			`"bar":[]*string{(*string)("foo"), (*string)("foo")}, `+
+			`"foo":<REC(map[string]interface{})>}, {`+
+			`"bar":[]*string{(*string)("foo"), (*string)("foo")}, `+
+			`"foo":<REC(map[string]interface{})>}}`)
+}
+
+func TestRenderImplicitType(t *testing.T) {
+	type namedStruct struct{ a, b int }
+	type namedInt int
+
+	tcs := []struct {
+		in     interface{}
+		expect string
+	}{
+		{
+			[]struct{ a, b int }{{1, 2}},
+			"[]struct { a int; b int }{{1, 2}}",
+		},
+		{
+			map[string]struct{ a, b int }{"hi": {1, 2}},
+			`map[string]struct { a int; b int }{"hi":{1, 2}}`,
+		},
+		{
+			map[namedInt]struct{}{10: {}},
+			`map[render.namedInt]struct {}{10:{}}`,
+		},
+		{
+			struct{ a, b int }{1, 2},
+			`struct { a int; b int }{1, 2}`,
+		},
+		{
+			namedStruct{1, 2},
+			"render.namedStruct{a:1, b:2}",
+		},
+	}
+
+	for _, tc := range tcs {
+		assertRendersLike(t, reflect.TypeOf(tc.in).String(), tc.in, tc.expect)
+	}
+}
+
+func ExampleInReadme() {
+	type customType int
+	type testStruct struct {
+		S string
+		V *map[string]int
+		I interface{}
+	}
+
+	a := testStruct{
+		S: "hello",
+		V: &map[string]int{"foo": 0, "bar": 1},
+		I: customType(42),
+	}
+
+	fmt.Println("Render test:")
+	fmt.Printf("fmt.Printf:    %s\n", sanitizePointer(fmt.Sprintf("%#v", a)))
+	fmt.Printf("render.Render: %s\n", Render(a))
+	// Output: Render test:
+	// fmt.Printf:    render.testStruct{S:"hello", V:(*map[string]int)(0x600dd065), I:42}
+	// render.Render: render.testStruct{S:"hello", V:(*map[string]int){"bar":1, "foo":0}, I:render.customType(42)}
+}
+
+var pointerRE = regexp.MustCompile(`\(0x[a-f0-9]+\)`)
+
+func sanitizePointer(s string) string {
+	return pointerRE.ReplaceAllString(s, "(0x600dd065)")
+}
+
+type chanList []chan int
+
+func (c chanList) Len() int      { return len(c) }
+func (c chanList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c chanList) Less(i, j int) bool {
+	return reflect.ValueOf(c[i]).Pointer() < reflect.ValueOf(c[j]).Pointer()
+}
+
+func TestMapSortRendering(t *testing.T) {
+	type namedMapType map[int]struct{ a int }
+	type mapKey struct{ a, b int }
+
+	chans := make(chanList, 5)
+	for i := range chans {
+		chans[i] = make(chan int)
+	}
+
+	tcs := []struct {
+		in     interface{}
+		expect string
+	}{
+		{
+			map[uint32]struct{}{1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}},
+			"map[uint32]struct {}{1:{}, 2:{}, 3:{}, 4:{}, 5:{}, 6:{}, 7:{}, 8:{}}",
+		},
+		{
+			map[int8]struct{}{1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}},
+			"map[int8]struct {}{1:{}, 2:{}, 3:{}, 4:{}, 5:{}, 6:{}, 7:{}, 8:{}}",
+		},
+		{
+			map[uintptr]struct{}{1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}},
+			"map[uintptr]struct {}{1:{}, 2:{}, 3:{}, 4:{}, 5:{}, 6:{}, 7:{}, 8:{}}",
+		},
+		{
+			namedMapType{10: struct{ a int }{20}},
+			"render.namedMapType{10:struct { a int }{20}}",
+		},
+		{
+			map[mapKey]struct{}{mapKey{3, 1}: {}, mapKey{1, 3}: {}, mapKey{1, 2}: {}, mapKey{2, 1}: {}},
+			"map[render.mapKey]struct {}{render.mapKey{a:1, b:2}:{}, render.mapKey{a:1, b:3}:{}, render.mapKey{a:2, b:1}:{}, render.mapKey{a:3, b:1}:{}}",
+		},
+		{
+			map[float64]struct{}{10.5: {}, 10.15: {}, 1203: {}, 1: {}, 2: {}},
+			"map[float64]struct {}{1:{}, 2:{}, 10.15:{}, 10.5:{}, 1203:{}}",
+		},
+		{
+			map[bool]struct{}{true: {}, false: {}},
+			"map[bool]struct {}{false:{}, true:{}}",
+		},
+		{
+			map[interface{}]struct{}{1: {}, 2: {}, 3: {}, "foo": {}},
+			`map[interface{}]struct {}{1:{}, 2:{}, 3:{}, "foo":{}}`,
+		},
+		{
+			map[complex64]struct{}{1 + 2i: {}, 2 + 1i: {}, 3 + 1i: {}, 1 + 3i: {}},
+			"map[complex64]struct {}{(1+2i):{}, (1+3i):{}, (2+1i):{}, (3+1i):{}}",
+		},
+		{
+			map[chan int]string{nil: "a", chans[0]: "b", chans[1]: "c", chans[2]: "d", chans[3]: "e", chans[4]: "f"},
+			`map[(chan int)]string{(chan int)(PTR):"a", (chan int)(PTR):"b", (chan int)(PTR):"c", (chan int)(PTR):"d", (chan int)(PTR):"e", (chan int)(PTR):"f"}`,
+		},
+	}
+
+	for _, tc := range tcs {
+		assertRendersLike(t, reflect.TypeOf(tc.in).Name(), tc.in, tc.expect)
+	}
+}

--- a/vendor/github.com/smartystreets/assertions/internal/go-render/render/render_time.go
+++ b/vendor/github.com/smartystreets/assertions/internal/go-render/render/render_time.go
@@ -1,0 +1,26 @@
+package render
+
+import (
+	"reflect"
+	"time"
+)
+
+func renderTime(value reflect.Value) (string, bool) {
+	if instant, ok := convertTime(value); !ok {
+		return "", false
+	} else if instant.IsZero() {
+		return "0", true
+	} else {
+		return instant.String(), true
+	}
+}
+
+func convertTime(value reflect.Value) (t time.Time, ok bool) {
+	if value.Type() == timeType {
+		defer func() { recover() }()
+		t, ok = value.Interface().(time.Time)
+	}
+	return
+}
+
+var timeType = reflect.TypeOf(time.Time{})

--- a/vendor/github.com/smartystreets/assertions/internal/unit/fixture.go
+++ b/vendor/github.com/smartystreets/assertions/internal/unit/fixture.go
@@ -1,0 +1,125 @@
+// package unit implements a light-weight x-Unit style testing framework.
+// It is basically a scaled-down version of github.com/smartystreets/gunit.
+// See https://smartystreets.com/blog/2018/07/lets-build-xunit-in-go for
+// an explanation of the basic moving parts.
+package unit
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func Run(fixture interface{}, t *testing.T) {
+	fixtureType := reflect.TypeOf(fixture)
+
+	for x := 0; x < fixtureType.NumMethod(); x++ {
+		testMethodName := fixtureType.Method(x).Name
+		if strings.HasPrefix(testMethodName, "Test") {
+			t.Run(testMethodName, func(t *testing.T) {
+				instance := reflect.New(fixtureType.Elem())
+
+				innerFixture := newFixture(t, testing.Verbose())
+				field := instance.Elem().FieldByName("Fixture")
+				field.Set(reflect.ValueOf(innerFixture))
+
+				defer innerFixture.Finalize()
+
+				if setup := instance.MethodByName("Setup"); setup.IsValid() {
+					setup.Call(nil)
+				}
+
+				instance.MethodByName(testMethodName).Call(nil)
+
+				if teardown := instance.MethodByName("Teardown"); teardown.IsValid() {
+					teardown.Call(nil)
+				}
+			})
+		}
+	}
+}
+
+type Fixture struct {
+	t       *testing.T
+	log     *bytes.Buffer
+	verbose bool
+}
+
+func newFixture(t *testing.T, verbose bool) *Fixture {
+	return &Fixture{t: t, verbose: verbose, log: &bytes.Buffer{}}
+}
+
+func (this *Fixture) So(actual interface{}, assert assertion, expected ...interface{}) bool {
+	failure := assert(actual, expected...)
+	failed := len(failure) > 0
+	if failed {
+		this.fail(failure)
+	}
+	return !failed
+}
+
+func (this *Fixture) fail(failure string) {
+	this.t.Fail()
+	this.Print(failure)
+}
+
+// Assert tests a boolean which, if not true, marks the current test case as failed and
+// prints the provided message.
+func (this *Fixture) Assert(condition bool, messages ...string) bool {
+	if !condition {
+		if len(messages) == 0 {
+			messages = append(messages, "Expected condition to be true, was false instead.")
+		}
+		this.fail(strings.Join(messages, ", "))
+	}
+	return condition
+}
+func (this *Fixture) AssertEqual(expected, actual interface{}) bool {
+	return this.Assert(expected == actual, fmt.Sprintf(comparisonFormat, fmt.Sprint(expected), fmt.Sprint(actual)))
+}
+func (this *Fixture) AssertSprintEqual(expected, actual interface{}) bool {
+	return this.AssertEqual(fmt.Sprint(expected), fmt.Sprint(actual))
+}
+func (this *Fixture) AssertSprintfEqual(expected, actual interface{}, format string) bool {
+	return this.AssertEqual(fmt.Sprintf(format, expected), fmt.Sprintf(format, actual))
+}
+func (this *Fixture) AssertDeepEqual(expected, actual interface{}) bool {
+	return this.Assert(reflect.DeepEqual(expected, actual),
+		fmt.Sprintf(comparisonFormat, fmt.Sprintf("%#v", expected), fmt.Sprintf("%#v", actual)))
+}
+
+const comparisonFormat = "Expected: [%s]\nActual:   [%s]"
+
+func (this *Fixture) Error(args ...interface{})            { this.fail(fmt.Sprint(args...)) }
+func (this *Fixture) Errorf(f string, args ...interface{}) { this.fail(fmt.Sprintf(f, args...)) }
+
+func (this *Fixture) Print(a ...interface{})                 { fmt.Fprint(this.log, a...) }
+func (this *Fixture) Printf(format string, a ...interface{}) { fmt.Fprintf(this.log, format, a...) }
+func (this *Fixture) Println(a ...interface{})               { fmt.Fprintln(this.log, a...) }
+
+func (this *Fixture) Write(p []byte) (int, error) { return this.log.Write(p) }
+func (this *Fixture) Failed() bool                { return this.t.Failed() }
+func (this *Fixture) Name() string                { return this.t.Name() }
+
+func (this *Fixture) Finalize() {
+	if r := recover(); r != nil {
+		this.recoverPanic(r)
+	}
+
+	if this.t.Failed() || (this.verbose && this.log.Len() > 0) {
+		this.t.Log("\n" + strings.TrimSpace(this.log.String()) + "\n")
+	}
+}
+func (this *Fixture) recoverPanic(r interface{}) {
+	this.Println("PANIC:", r)
+	buffer := make([]byte, 1024*16)
+	runtime.Stack(buffer, false)
+	this.Println(strings.TrimSpace(string(buffer)))
+	this.t.Fail()
+}
+
+// assertion is a copy of github.com/smartystreets/assertions.assertion.
+type assertion func(actual interface{}, expected ...interface{}) string

--- a/vendor/github.com/smartystreets/assertions/messages.go
+++ b/vendor/github.com/smartystreets/assertions/messages.go
@@ -17,6 +17,7 @@ const ( // equality
 	shouldHaveBeenTrue              = "Expected: true\nActual:   %v"
 	shouldHaveBeenFalse             = "Expected: false\nActual:   %v"
 	shouldHaveBeenZeroValue         = "'%+v' should have been the zero value" //"Expected: (zero value)\nActual:   %v"
+	shouldNotHaveBeenZeroValue      = "'%+v' should NOT have been the zero value"
 )
 
 const ( // quantity comparisons
@@ -44,7 +45,7 @@ const ( // collections
 	shouldNotHaveBeenEmpty         = "Expected %+v to NOT be empty (but it was)!"
 	shouldHaveBeenAValidInteger    = "You must provide a valid integer (was %v)!"
 	shouldHaveBeenAValidLength     = "You must provide a valid positive integer (was %v)!"
-	shouldHaveHadLength            = "Expected %+v (length: %v) to have length equal to '%v', but it wasn't!"
+	shouldHaveHadLength            = "Expected collection to have length equal to [%v], but it's length was [%v] instead! contents: %+v"
 )
 
 const ( // strings

--- a/vendor/github.com/smartystreets/assertions/should/should.go
+++ b/vendor/github.com/smartystreets/assertions/should/should.go
@@ -9,6 +9,7 @@ var (
 	NotEqual       = assertions.ShouldNotEqual
 	AlmostEqual    = assertions.ShouldAlmostEqual
 	NotAlmostEqual = assertions.ShouldNotAlmostEqual
+	EqualJSON      = assertions.ShouldEqualJSON
 	Resemble       = assertions.ShouldResemble
 	NotResemble    = assertions.ShouldNotResemble
 	PointTo        = assertions.ShouldPointTo
@@ -18,6 +19,7 @@ var (
 	BeTrue         = assertions.ShouldBeTrue
 	BeFalse        = assertions.ShouldBeFalse
 	BeZeroValue    = assertions.ShouldBeZeroValue
+	NotBeZeroValue = assertions.ShouldNotBeZeroValue
 
 	BeGreaterThan          = assertions.ShouldBeGreaterThan
 	BeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo

--- a/vendor/github.com/smartystreets/assertions/utilities_for_test.go
+++ b/vendor/github.com/smartystreets/assertions/utilities_for_test.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/smartystreets/gunit"
+	"github.com/smartystreets/assertions/internal/unit"
 )
 
 /**************************************************************************/
 
 func TestAssertionsFixture(t *testing.T) {
-	gunit.Run(new(AssertionsFixture), t)
+	unit.Run(new(AssertionsFixture), t)
 }
 
 type AssertionsFixture struct {
-	*gunit.Fixture
+	*unit.Fixture
 }
 
 func (this *AssertionsFixture) Setup() {

--- a/vendor/github.com/smartystreets/goconvey/.travis.yml
+++ b/vendor/github.com/smartystreets/goconvey/.travis.yml
@@ -8,7 +8,11 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
-  - tip
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - master
 
 install:
   - go get -t ./...

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -16,6 +16,7 @@ var (
 	ShouldBeTrue         = assertions.ShouldBeTrue
 	ShouldBeFalse        = assertions.ShouldBeFalse
 	ShouldBeZeroValue    = assertions.ShouldBeZeroValue
+	ShouldNotBeZeroValue = assertions.ShouldNotBeZeroValue
 
 	ShouldBeGreaterThan          = assertions.ShouldBeGreaterThan
 	ShouldBeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo

--- a/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
@@ -19,7 +19,7 @@ func ResolveExternalCaller() (file string, line int, name string) {
 			return
 		}
 	}
-	file, line, name = "<unkown file>", -1, "<unknown name>"
+	file, line, name = "<unknown file>", -1, "<unknown name>"
 	return // panic?
 }
 

--- a/vendor/github.com/smartystreets/goconvey/convey/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/init.go
@@ -20,7 +20,7 @@ func init() {
 func declareFlags() {
 	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
 	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
-	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirrors the value of the '-test.v' flag")
 
 	if noStoryFlagProvided() {
 		story = verboseEnabled

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
@@ -56,7 +56,7 @@ var (
 	dotError        = "E"
 	dotSkip         = "S"
 	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
-	failureTemplate = "* %s \nLine %d:\n%s\n"
+	failureTemplate = "* %s \nLine %d:\n%s\n%s\n"
 )
 
 var (

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
@@ -30,11 +30,14 @@ func (self *Printer) format(message string, values ...interface{}) string {
 	if len(values) == 0 {
 		formatted = self.prefix + message
 	} else {
-		formatted = self.prefix + fmt.Sprintf(message, values...)
+		formatted = self.prefix + fmt_Sprintf(message, values...)
 	}
 	indented := strings.Replace(formatted, newline, newline+self.prefix, -1)
 	return strings.TrimRight(indented, space)
 }
+
+// Extracting fmt.Sprintf to a separate variable circumvents go vet, which, as of go 1.10 is run with go test.
+var fmt_Sprintf = fmt.Sprintf
 
 func (self *Printer) Indent() {
 	self.prefix += pad

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer_test.go
@@ -31,7 +31,7 @@ func TestPrintFormat(t *testing.T) {
 func TestPrintPreservesEncodedStrings(t *testing.T) {
 	file := newMemoryFile()
 	printer := NewPrinter(file)
-	const expected = "= -> %3D"
+	const expected = "= -> %%3D"
 	printer.Print(expected)
 
 	if file.buffer != expected {
@@ -68,7 +68,7 @@ func TestPrintlnFormat(t *testing.T) {
 func TestPrintlnPreservesEncodedStrings(t *testing.T) {
 	file := newMemoryFile()
 	printer := NewPrinter(file)
-	const expected = "= -> %3D"
+	const expected = "= -> %%3D"
 	printer.Println(expected)
 
 	if file.buffer != expected+"\n" {

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
@@ -53,7 +53,7 @@ func (self *problem) showFailures() {
 			self.out.Println("\nFailures:\n")
 			self.out.Indent()
 		}
-		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+		self.out.Println(failureTemplate, f.File, f.Line, f.Failure, f.StackTrace)
 	}
 }
 

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reporter_test.go
@@ -56,7 +56,7 @@ func assertEqual(t *testing.T, expected, actual int) {
 func assertNil(t *testing.T, err error) {
 	if err != nil {
 		_, _, line, _ := runtime.Caller(1)
-		t.Errorf("Error should have been <nil> (but wasn't). See line %d", err, line)
+		t.Errorf("Error should have been <nil> (but wasn't). See line %d. %v", err, line)
 	}
 }
 

--- a/vendor/github.com/smartystreets/goconvey/convey/story_conventions_test.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/story_conventions_test.go
@@ -16,7 +16,7 @@ func expectPanic(t *testing.T, f string) interface{} {
 			t.Errorf("Incorrect panic type. %s", reflect.TypeOf(r))
 		}
 	} else {
-		t.Error("Expected panic but none occured")
+		t.Error("Expected panic but none occurred")
 	}
 	return r
 }

--- a/vendor/github.com/smartystreets/goconvey/examples/assertion_examples_test.go
+++ b/vendor/github.com/smartystreets/goconvey/examples/assertion_examples_test.go
@@ -31,6 +31,7 @@ func TestAssertionsAreAvailableFromConveyPackage(t *testing.T) {
 		So(true, ShouldBeTrue)
 		So(false, ShouldBeFalse)
 		So(0, ShouldBeZeroValue)
+		So(1, ShouldNotBeZeroValue)
 	})
 
 	Convey("Numeric comparison assertions should be accessible", t, func() {

--- a/vendor/github.com/smartystreets/goconvey/go.mod
+++ b/vendor/github.com/smartystreets/goconvey/go.mod
@@ -1,0 +1,7 @@
+module github.com/smartystreets/goconvey
+
+require (
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+)

--- a/vendor/github.com/smartystreets/goconvey/go.sum
+++ b/vendor/github.com/smartystreets/goconvey/go.sum
@@ -1,0 +1,6 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/vendor/github.com/smartystreets/goconvey/goconvey.go
+++ b/vendor/github.com/smartystreets/goconvey/goconvey.go
@@ -13,7 +13,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,9 +89,9 @@ func main() {
 
 func browserCmd() (string, bool) {
 	browser := map[string]string{
-		"darwin": "open",
-		"linux":  "xdg-open",
-		"win32":  "start",
+		"darwin":  "open",
+		"linux":   "xdg-open",
+		"windows": "start",
 	}
 	cmd, ok := browser[runtime.GOOS]
 	return cmd, ok
@@ -198,17 +200,25 @@ func activateServer(listener net.Listener) {
 
 func coverageEnabled(cover bool, reports string) bool {
 	return (cover &&
-		goVersion_1_2_orGreater() &&
+		goMinVersion(1, 2) &&
 		coverToolInstalled() &&
 		ensureReportDirectoryExists(reports))
 }
-func goVersion_1_2_orGreater() bool {
+func goMinVersion(wanted ...int) bool {
 	version := runtime.Version() // 'go1.2....'
-	major, minor := version[2], version[4]
-	version_1_2 := major >= byte('1') && minor >= byte('2')
-	if !version_1_2 {
-		log.Printf(pleaseUpgradeGoVersion, version)
+	s := regexp.MustCompile(`go([\d]+)\.([\d]+)\.?([\d]+)?`).FindAllStringSubmatch(version, 1)
+	if len(s) == 0 {
+		log.Printf("Cannot determine if newer than go1.2, disabling coverage.")
 		return false
+	}
+	for idx, str := range s[0][1:] {
+		if len(wanted) == idx {
+			break
+		}
+		if v, _ := strconv.Atoi(str); v < wanted[idx] {
+			log.Printf(pleaseUpgradeGoVersion, version)
+			return false
+		}
 	}
 	return true
 }

--- a/vendor/github.com/smartystreets/goconvey/web/server/api/server_test.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/api/server_test.go
@@ -25,7 +25,7 @@ func TestHTTPServer(t *testing.T) {
 	Convey("Subject: HttpServer responds to requests appropriately", t, func() {
 		fixture := newServerFixture()
 
-		Convey("Before any update is recieved", func() {
+		Convey("Before any update is received", func() {
 			Convey("When the update is requested", func() {
 				update, _ := fixture.RequestLatest()
 
@@ -146,7 +146,7 @@ func TestHTTPServer(t *testing.T) {
 			})
 		})
 
-		SkipConvey("When a packge is ignored", func() {
+		SkipConvey("When a package is ignored", func() {
 
 			Convey("But the request has no path parameter", func() {
 				status, body := fixture.IgnoreMalformed()

--- a/vendor/github.com/smartystreets/goconvey/web/server/parser/packageParser.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/parser/packageParser.go
@@ -95,8 +95,11 @@ func (self *outputParser) processTestOutput() {
 }
 
 func (self *outputParser) registerTestFunction() {
-	testName := testNamePattern.FindStringSubmatch(self.line)[1]
-	self.test = contract.NewTestResult(testName)
+	testNameReg := testNamePattern.FindStringSubmatch(self.line)
+	if len(testNameReg) < 2 { // Test-related lines that aren't about a new test
+		return
+	}
+	self.test = contract.NewTestResult(testNameReg[1])
 	self.tests = append(self.tests, self.test)
 	self.testMap[self.test.TestName] = self.test
 }

--- a/vendor/github.com/smartystreets/goconvey/web/server/parser/package_parser_test.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/parser/package_parser_test.go
@@ -68,6 +68,18 @@ func TestParsePackage_OldSchoolWithSuccessOutput_ReturnsCompletePackageResult(t 
 	assertEqual(t, expectedOldSchool_Passes, *actual)
 }
 
+func TestParsePackage_GoConveyWithDiffOutput_ReturnsPackageResult(t *testing.T) {
+	actual := &contract.PackageResult{PackageName: expectedOldSchoolWithDiff_Fails.PackageName}
+	ParsePackageResults(actual, inputOldSchoolWithDiff_Fails)
+	assertEqual(t, expectedOldSchoolWithDiff_Fails, *actual)
+}
+
+func TestParsePackage_GoConveyWithDiff2Output_ReturnsPackageResult(t *testing.T) {
+	actual := &contract.PackageResult{PackageName: expectedOldSchoolWithDiff2_Fails.PackageName}
+	ParsePackageResults(actual, inputOldSchoolWithDiff2_Fails)
+	assertEqual(t, expectedOldSchoolWithDiff2_Fails, *actual)
+}
+
 func TestParsePackage_OldSchoolWithPanicOutput_ReturnsCompletePackageResult(t *testing.T) {
 	actual := &contract.PackageResult{PackageName: expectedOldSchool_Panics.PackageName}
 	ParsePackageResults(actual, inputOldSchool_Panics)
@@ -324,6 +336,186 @@ var expectedOldSchool_Fails = contract.PackageResult{
 			File:     "",
 			Line:     0,
 			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestOldSchool_FailureWithReason",
+			Elapsed:  0.11,
+			Passed:   false,
+			File:     "old_school_test.go",
+			Line:     18,
+			Message:  "old_school_test.go:18: I am a failing test.",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestOldSchool_Passes",
+			Elapsed:  0.01,
+			Passed:   true,
+			File:     "",
+			Line:     0,
+			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestOldSchool_PassesWithMessage",
+			Elapsed:  0.03,
+			Passed:   true,
+			File:     "old_school_test.go",
+			Line:     10,
+			Message:  "old_school_test.go:10: I am a passing test.\nWith a newline.",
+			Stories:  []reporting.ScopeResult{},
+		},
+	},
+}
+
+const inputOldSchoolWithDiff2_Fails = `
+/home/apryl/gopath/src/gitlab.qarea.org/tgms/collabms/tracker/testdata/staging.setup: 11: /home/apryl/gopath/src/gitlab.qarea.org/tgms/collabms/tracker/testdata/staging.setup: [[: not found
+=== RUN   TestExterlanLoginURL
+--- PASS: TestExterlanLoginURL (0.00s)
+=== RUN   TestToProject
+--- FAIL: TestToProject (0.00s)
+        Error Trace:    converters_test.go:29
+        Error:          Not equal: entities.Project{ID:"1", Title:"Todolist1", Link:"host.com/123/projects/1", Description:"", IssueTypes:[]entities.TypeID{entities.TypeID{ID:5, Name:"NEW"}, entities.TypeID{ID:6, Name:"CONFIRMED"}, entities.TypeID{ID:7, Name:"WORKS FOR ME"}}, ActivityTypes:[]entities.TypeID{entities.TypeID{ID:1, Name:"General"}, entities.TypeID{ID:2, Name:"i don't know"}, entities.TypeID{ID:3, Name:"maaaan"}}} (expected)
+                                != entities.Project{ID:"1", Title:"Todolist", Link:"host.com/123/projects/1", Description:"", IssueTypes:[]entities.TypeID{entities.TypeID{ID:5, Name:"NEW"}, entities.TypeID{ID:6, Name:"CONFIRMED"}, entities.TypeID{ID:7, Name:"WORKS FOR ME"}}, ActivityTypes:[]entities.TypeID{entities.TypeID{ID:1, Name:"General"}, entities.TypeID{ID:2, Name:"i don't know"}, entities.TypeID{ID:3, Name:"maaaan"}}} (actual)
+
+                        Diff:
+                        --- Expected
+                        +++ Actual
+                        @@ -2,6 +2,6 @@
+                          ID: (entities.ProjectID) (len=1) "1",
+                        - Title: (string) (len=9) "Todolist1",
+                        + Title: (string) (len=8) "Todolist",
+                          Link: (string) (len=23) "host.com/123/projects/1",
+                          Description: (string) "",
+                        - IssueTypes: ([]entities.TypeID) (len=3 cap=3) {
+                        + IssueTypes: ([]entities.TypeID) (len=3 cap=4) {
+                           (entities.TypeID) {
+                        @@ -19,3 +19,3 @@
+                          },
+                        - ActivityTypes: ([]entities.TypeID) (len=3 cap=3) {
+                        + ActivityTypes: ([]entities.TypeID) (len=3 cap=4) {
+                           (entities.TypeID) {
+
+=== RUN   TestIssue
+--- FAIL: TestIssue (0.00s)
+        Error Trace:    converters_test.go:49
+        Error:          Not equal: entities.Issue{ID:"1", ProjectID:"1", Type:entities.TypeID{ID:8, Name:"DUPLICATE"}, Title:"ser1", Description:"", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:"host.com/123/projects/1/tasks/1"} (expected)
+                                != entities.Issue{ID:"1", ProjectID:"1", Type:entities.TypeID{ID:8, Name:"DUPLICATE"}, Title:"ser", Description:"", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:"host.com/123/projects/1/tasks/1"} (actual)
+
+                        Diff:
+                        --- Expected
+                        +++ Actual
+                        @@ -7,3 +7,3 @@
+                          },
+                        - Title: (string) (len=4) "ser1",
+                        + Title: (string) (len=3) "ser",
+                          Description: (string) "",
+        Messages:       Message
+
+=== RUN   TestIssues
+--- PASS: TestIssues (2.00s)
+FAIL
+coverage: 51.7% of statements
+exit status 1
+FAIL	github.com/smartystreets/goconvey/webserver/examples	0.414s
+`
+
+var expectedOldSchoolWithDiff2_Fails = contract.PackageResult{
+	PackageName: "github.com/smartystreets/goconvey/webserver/examples",
+	Outcome:     contract.Failed,
+	Elapsed:     0.414,
+	Coverage:    51.7,
+	TestResults: []contract.TestResult{
+		contract.TestResult{
+			TestName: "TestExterlanLoginURL",
+			Elapsed:  0.00,
+			Passed:   true,
+			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestIssue",
+			Elapsed:  0.00,
+			Passed:   false,
+			File:     "converters_test.go",
+			Line:     49,
+			Message:  "Error Trace:    converters_test.go:49\nError:          Not equal: entities.Issue{ID:\"1\", ProjectID:\"1\", Type:entities.TypeID{ID:8, Name:\"DUPLICATE\"}, Title:\"ser1\", Description:\"\", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:\"host.com/123/projects/1/tasks/1\"} (expected)\n!= entities.Issue{ID:\"1\", ProjectID:\"1\", Type:entities.TypeID{ID:8, Name:\"DUPLICATE\"}, Title:\"ser\", Description:\"\", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:\"host.com/123/projects/1/tasks/1\"} (actual)\n\nDiff:\n--- Expected\n+++ Actual\n@@ -7,3 +7,3 @@\n},\n- Title: (string) (len=4) \"ser1\",\n+ Title: (string) (len=3) \"ser\",\nDescription: (string) \"\",\nMessages:       Message\n",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestIssues",
+			Elapsed:  2.00,
+			Passed:   true,
+			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestToProject",
+			Elapsed:  0.00,
+			Passed:   false,
+			File:     "converters_test.go",
+			Line:     29,
+			Message:  "Error Trace:    converters_test.go:29\nError:          Not equal: entities.Project{ID:\"1\", Title:\"Todolist1\", Link:\"host.com/123/projects/1\", Description:\"\", IssueTypes:[]entities.TypeID{entities.TypeID{ID:5, Name:\"NEW\"}, entities.TypeID{ID:6, Name:\"CONFIRMED\"}, entities.TypeID{ID:7, Name:\"WORKS FOR ME\"}}, ActivityTypes:[]entities.TypeID{entities.TypeID{ID:1, Name:\"General\"}, entities.TypeID{ID:2, Name:\"i don't know\"}, entities.TypeID{ID:3, Name:\"maaaan\"}}} (expected)\n!= entities.Project{ID:\"1\", Title:\"Todolist\", Link:\"host.com/123/projects/1\", Description:\"\", IssueTypes:[]entities.TypeID{entities.TypeID{ID:5, Name:\"NEW\"}, entities.TypeID{ID:6, Name:\"CONFIRMED\"}, entities.TypeID{ID:7, Name:\"WORKS FOR ME\"}}, ActivityTypes:[]entities.TypeID{entities.TypeID{ID:1, Name:\"General\"}, entities.TypeID{ID:2, Name:\"i don't know\"}, entities.TypeID{ID:3, Name:\"maaaan\"}}} (actual)\n\nDiff:\n--- Expected\n+++ Actual\n@@ -2,6 +2,6 @@\nID: (entities.ProjectID) (len=1) \"1\",\n- Title: (string) (len=9) \"Todolist1\",\n+ Title: (string) (len=8) \"Todolist\",\nLink: (string) (len=23) \"host.com/123/projects/1\",\nDescription: (string) \"\",\n- IssueTypes: ([]entities.TypeID) (len=3 cap=3) {\n+ IssueTypes: ([]entities.TypeID) (len=3 cap=4) {\n(entities.TypeID) {\n@@ -19,3 +19,3 @@\n},\n- ActivityTypes: ([]entities.TypeID) (len=3 cap=3) {\n+ ActivityTypes: ([]entities.TypeID) (len=3 cap=4) {\n(entities.TypeID) {\n",
+			Stories:  []reporting.ScopeResult{},
+		},
+	},
+}
+
+const inputOldSchoolWithDiff_Fails = `
+/home/apryl/gopath/src/gitlab.qarea.org/tgms/collabms/tracker/testdata/staging.setup: 11: /home/apryl/gopath/src/gitlab.qarea.org/tgms/collabms/tracker/testdata/staging.setup: [[: not found
+=== RUN TestOldSchool_Passes
+--- PASS: TestOldSchool_Passes (0.01 seconds)
+=== RUN TestOldSchool_PassesWithMessage
+--- PASS: TestOldSchool_PassesWithMessage (0.03 seconds)
+	old_school_test.go:10: I am a passing test.
+		With a newline.
+=== RUN TestOldSchool_Failure
+--- FAIL: TestOldSchool_Failure (0.06 seconds)
+=== RUN TestOldSchool_FailureWithReason
+--- FAIL: TestOldSchool_FailureWithReason (0.11 seconds)
+	old_school_test.go:18: I am a failing test.
+=== RUN TestOldSchool_FailureWithDiff
+--- FAIL: TestOldSchool_FailureWithDiff (0.17 seconds)
+        Error Trace:    converters_test.go:49
+        Error:          Not equal: entities.Issue{ID:"1", ProjectID:"1", Type:entities.TypeID{ID:8, Name:"DUPLICATE"}, Title:"ser1", Description:"", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:"host.com/123/projects/1/tasks/1"} (expected)
+                                != entities.Issue{ID:"1", ProjectID:"1", Type:entities.TypeID{ID:8, Name:"DUPLICATE"}, Title:"ser", Description:"", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:"host.com/123/projects/1/tasks/1"} (actual)
+
+                        Diff:
+                        --- Expected
+                        +++ Actual
+                        @@ -7,3 +7,3 @@
+                          },
+                        - Title: (string) (len=4) "ser1",
+                        + Title: (string) (len=3) "ser",
+                          Description: (string) "",
+        Messages:       Message
+
+FAIL
+exit status 1
+FAIL	github.com/smartystreets/goconvey/webserver/examples	0.017s
+`
+
+var expectedOldSchoolWithDiff_Fails = contract.PackageResult{
+	PackageName: "github.com/smartystreets/goconvey/webserver/examples",
+	Outcome:     contract.Failed,
+	Elapsed:     0.017,
+	TestResults: []contract.TestResult{
+		contract.TestResult{
+			TestName: "TestOldSchool_Failure",
+			Elapsed:  0.06,
+			Passed:   false,
+			File:     "",
+			Line:     0,
+			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+		contract.TestResult{
+			TestName: "TestOldSchool_FailureWithDiff",
+			Elapsed:  0.17,
+			Passed:   false,
+			File:     "converters_test.go",
+			Line:     49,
+			Message:  "Error Trace:    converters_test.go:49\nError:          Not equal: entities.Issue{ID:\"1\", ProjectID:\"1\", Type:entities.TypeID{ID:8, Name:\"DUPLICATE\"}, Title:\"ser1\", Description:\"\", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:\"host.com/123/projects/1/tasks/1\"} (expected)\n!= entities.Issue{ID:\"1\", ProjectID:\"1\", Type:entities.TypeID{ID:8, Name:\"DUPLICATE\"}, Title:\"ser\", Description:\"\", Estimate:19800, DueDate:1479859200, Done:0, Spent:23400, URL:\"host.com/123/projects/1/tasks/1\"} (actual)\n\nDiff:\n--- Expected\n+++ Actual\n@@ -7,3 +7,3 @@\n},\n- Title: (string) (len=4) \"ser1\",\n+ Title: (string) (len=3) \"ser\",\nDescription: (string) \"\",\nMessages:       Message\n",
 			Stories:  []reporting.ScopeResult{},
 		},
 		contract.TestResult{

--- a/vendor/github.com/smartystreets/goconvey/web/server/parser/rules.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/parser/rules.go
@@ -4,12 +4,14 @@ import "strings"
 
 func noGoFiles(line string) bool {
 	return strings.HasPrefix(line, "can't load package: ") &&
-		strings.Contains(line, ": no buildable Go source files in ")
+		(strings.Contains(line, ": no buildable Go source files in ") ||
+			strings.Contains(line, ": no Go ") ||
+			strings.Contains(line, "cannot find module providing package"))
 }
 func buildFailed(line string) bool {
 	return strings.HasPrefix(line, "# ") ||
 		strings.Contains(line, "cannot find package") ||
-		(strings.HasPrefix(line, "can't load package: ") && !strings.Contains(line, ": no Go source files in ")) ||
+		(strings.HasPrefix(line, "can't load package: ") && !strings.Contains(line, ": no Go ")) ||
 		(strings.Contains(line, ": found packages ") && strings.Contains(line, ".go) and ") && strings.Contains(line, ".go) in "))
 }
 func noTestFunctions(line string) bool {
@@ -22,7 +24,7 @@ func isNewTest(line string) bool {
 	return strings.HasPrefix(line, "=== ")
 }
 func isTestResult(line string) bool {
-	return strings.HasPrefix(line, "--- ")
+	return strings.HasPrefix(line, "--- FAIL:") || strings.HasPrefix(line, "--- PASS:") || strings.HasPrefix(line, "--- SKIP:")
 }
 func isPackageReport(line string) bool {
 	return (strings.HasPrefix(line, "FAIL") ||

--- a/vendor/github.com/smartystreets/goconvey/web/server/parser/testParser.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/parser/testParser.go
@@ -118,7 +118,10 @@ func (self *testParser) preserveStackTraceIndentation(index int, line string) {
 }
 func (self *testParser) parseLogLocation() {
 	self.otherLines = append(self.otherLines, self.line)
-	lineFields := self.line
+	lineFields := strings.TrimSpace(self.line)
+	if strings.HasPrefix(lineFields, "Error Trace:") {
+		lineFields = strings.TrimPrefix(lineFields, "Error Trace:")
+	}
 	fields := strings.Split(lineFields, ":")
 	self.test.File = strings.TrimSpace(fields[0])
 	self.test.Line, _ = strconv.Atoi(fields[1])

--- a/vendor/github.com/smartystreets/goconvey/web/server/parser/util.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/parser/util.go
@@ -11,12 +11,16 @@ import (
 // --- PASS: TestOldSchool_PassesWithMessage (0.03 seconds)
 func parseTestFunctionDuration(line string) float64 {
 	line = strings.Replace(line, "(", "", 1)
+	line = strings.Replace(line, ")", "", 1)
 	fields := strings.Split(line, " ")
-	return parseDurationInSeconds(fields[3]+"s", 2)
+	return parseDurationInSeconds(fields[3], 2)
 }
 
 func parseDurationInSeconds(raw string, precision int) float64 {
-	elapsed, _ := time.ParseDuration(raw)
+	elapsed, err := time.ParseDuration(raw)
+	if err != nil {
+		elapsed, _ = time.ParseDuration(raw + "s")
+	}
 	return round(elapsed.Seconds(), precision)
 }
 

--- a/vendor/github.com/smartystreets/goconvey/web/server/system/shell.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/system/shell.go
@@ -49,7 +49,7 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 ///////////////////////////////////////////////////////////////////////////////
 
 func findGoConvey(directory, gobin, packageName, tagsArg string) Command {
-	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}'", tagsArg, packageName)
+	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}{{.XTestImports}}'", tagsArg, packageName)
 }
 
 func compile(directory, gobin, tagsArg string) Command {

--- a/vendor/github.com/smartystreets/goconvey/web/server/watch/functional_core_test.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/watch/functional_core_test.go
@@ -404,7 +404,7 @@ func TestActiveFolders(t *testing.T) {
 }
 
 func TestSum(t *testing.T) {
-	Convey("Subject: file system items within specified directores should be counted and summed", t, func() {
+	Convey("Subject: file system items within specified directories should be counted and summed", t, func() {
 		folders := map[string]*messaging.Folder{
 			"/root/1": {Path: "/root/1", Root: "/root", Ignored: true},
 		}

--- a/vendor/github.com/smartystreets/goconvey/web/server/watch/integration.go
+++ b/vendor/github.com/smartystreets/goconvey/web/server/watch/integration.go
@@ -58,7 +58,7 @@ func (this *Watcher) Listen() {
 			if !this.paused {
 				this.scan()
 			}
-			time.Sleep(nap)
+			time.Sleep(this.nap)
 		}
 	}
 }
@@ -181,5 +181,3 @@ func (this *Watcher) protectedRead(protected func()) {
 	defer this.lock.RUnlock()
 	protected()
 }
-
-const nap = time.Millisecond * 250


### PR DESCRIPTION
Hey @relistan, this is a big-ish PR with quite a few cleanup changes that I'd like to get merged before I proceed with implementing #44. It was a good way for me to re-explore the code a bit and see what's in here. I'm happy to do adjust these changes in any way or not do them at all, but the main goal was to remove all warnings reported by [golangci-lint](https://github.com/golangci/golangci-lint) and enable it for Travis builds.

Changes to  review individually:
- 4ae802a - Go 1.12 [is making goconvey panic](https://github.com/smartystreets/goconvey/issues/561) so I updated it to latest. I had to fiddle around with getting Dep to update https://github.com/jtolds/gls as a transitive dependency.
- c69b1b9 - syscall.SIGSTOP can't be trapped or ignored, so no point trying
- 5d2c03d - Refactor deprecated http.CloseNotifier. **Please have a close look at this one.**
- 2ea6bbc - This looks broken in the current code. The linter has revealed the issue.
- ae4cdf0 - Log errors returned by RemoveListener - Initially, I was lazy and thought it would be simpler to not return errors at all from this function. I reverted that change and added error checks higher up the call stack based on the feedback [here](https://github.com/Nitro/sidecar/commit/013e977867a780e46767180481af30f921b1bac0#r33064567).
- 73272a4 - Change the state in `StateChangedEvent` to be a pointer type - It looks like this should have been a pointer from the beginning to avoid warnings about potentially copying locks around. I don't think I'm breaking anything by changing this struct.
- ed842f9 - Return error from service.Decode if the input can't be decoded - Refactored according to the feedback received [here](https://github.com/Nitro/sidecar/commit/fd9d9d6ba1bae6e0392c10d3927ca77fae9ebb8c#r33064586). Sidecar only uses this function [here](https://github.com/Nitro/sidecar/blob/8327834c20bca8a155ccac8bc42ab2f42ca925a6/services_delegate.go#L48) and [`haproxy-api`](https://github.com/Nitro/haproxy-api) doesn't seem to use it.
- 45322d7 - Make the `--cluster-ip` flag optional and check Kingpin parse errors - We weren't checking the error when parsing the Kingpin flags, so this flag was never mandatory. Looking at its usage, I don't think it should be, given that it stomps over whatever is set in the `SIDECAR_SEEDS` environment variable. I adjusted the Readme to explain this.
- 784edf6 - Generic code cleanup, error handling and extra logging. Shouldn't change any behaviour, but please check.
- 49a5b0c - Travis cleanup - Seems to still work, so should be fine
- b7a13df - Enable [golangci-lint](https://github.com/golangci/golangci-lint) for Travis builds, yay!
- 4f60f24 - Bump up go to 1.12. The latest `golangci-lint` needs at least go 1.10, so I thought it's best to just upgrade to the latest version. I can fall back to go 1.10 if you prefer that.