### PR TITLE
Add service DRAINING status and a handler for the `drain` HTTP API endpoint

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -331,6 +331,22 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 	}
 }
 
+// GetLocalServiceByID returns a service for a given ID if it
+// happens to exist on the current host. Returns an error otherwise.
+func (state *ServicesState) GetLocalServiceByID(id string) (service.Service, error) {
+	state.RLock()
+	defer state.RUnlock()
+
+	if server, ok := state.Servers[state.Hostname]; ok {
+		if svc, ok := server.Services[id]; ok {
+			return *svc, nil
+		}
+	}
+
+	return service.Service{},
+		fmt.Errorf("service with ID %q not found on host %q", id, state.Hostname)
+}
+
 // Merge a complete state struct into this one. Usually used on
 // node startup and during anti-entropy operations.
 func (state *ServicesState) Merge(otherState *ServicesState) {

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -614,8 +614,8 @@ func (state *ServicesState) TombstoneOthersServices() []service.Service {
 		// removal if it exceeds the allowed ALIVE_TIMESPAN
 		if !svc.IsTombstone() &&
 			svc.Updated.Before(time.Now().UTC().Add(0-ALIVE_LIFESPAN)) {
-			log.Warnf("Found expired service %s from %s, tombstoning",
-				svc.Name, svc.Hostname,
+			log.Warnf("Found expired service %s ID %s from %s, tombstoning",
+				svc.Name, svc.ID, svc.Hostname,
 			)
 
 			// Because we don't know that other hosts haven't gotten a newer

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -309,6 +309,11 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 		// Store the previous newSvc so we can compare it
 		oldEntry := server.Services[newSvc.ID]
 
+		// Make sure we preserve the DRAINING status for services
+		if oldEntry.Status == service.DRAINING && newSvc.Status == service.ALIVE {
+			newSvc.Status = oldEntry.Status
+		}
+
 		// Update the new one
 		server.Services[newSvc.ID] = &newSvc
 

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -248,6 +248,32 @@ func Test_ServicesStateWithData(t *testing.T) {
 			})
 		})
 
+		Convey("GetLocalServiceByID()", func() {
+			Convey("Returns an existing service on the current host", func() {
+				state.Hostname = anotherHostname
+				state.AddServiceEntry(svc)
+
+				returnedSvc, err := state.GetLocalServiceByID(svc.ID)
+				So(err, ShouldBeNil)
+				So(returnedSvc.ID, ShouldEqual, svc.ID)
+			})
+
+			Convey("Doesn't return a service running on other hosts", func() {
+				state.AddServiceEntry(svc)
+
+				_, err := state.GetLocalServiceByID(svc.ID)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Returns an error for a non-existent service ID", func() {
+				state.AddServiceEntry(svc)
+
+				_, err := state.GetLocalServiceByID("missing")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "not found")
+			})
+		})
+
 		Convey("Merge() merges state we care about from other state structs", func() {
 			firstState := NewServicesState()
 			secondState := NewServicesState()

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -219,6 +219,33 @@ func Test_ServicesStateWithData(t *testing.T) {
 				}
 				So(pendingBroadcast, ShouldBeFalse)
 			})
+
+			Convey("Sets a service's status to DRAINING", func() {
+				state.AddServiceEntry(svc)
+
+				svc.Status = service.DRAINING
+				svc.Updated = time.Now().UTC()
+
+				state.AddServiceEntry(svc)
+
+				So(state.HasServer(anotherHostname), ShouldBeTrue)
+				So(state.Servers[anotherHostname].Services[svc.ID].Status,
+					ShouldEqual, service.DRAINING)
+			})
+
+			Convey("Doesn't mark a DRAINING service as ALIVE", func() {
+				svc.Status = service.DRAINING
+				state.AddServiceEntry(svc)
+
+				svc.Status = service.ALIVE
+				svc.Updated = time.Now().UTC()
+
+				state.AddServiceEntry(svc)
+
+				So(state.HasServer(anotherHostname), ShouldBeTrue)
+				So(state.Servers[anotherHostname].Services[svc.ID].Status,
+					ShouldEqual, service.DRAINING)
+			})
 		})
 
 		Convey("Merge() merges state we care about from other state structs", func() {

--- a/healthy/healthy.go
+++ b/healthy/healthy.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/Nitro/sidecar/service"
-	log "github.com/sirupsen/logrus"
 	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -57,6 +57,8 @@ func ShouldNotify(oldStatus int, newStatus int) bool {
 		if oldStatus == service.ALIVE {
 			return true
 		}
+	case service.DRAINING:
+		return true
 	default:
 		log.Errorf("Got unknown service change status: %d", newStatus)
 		return false

--- a/service/service.go
+++ b/service/service.go
@@ -57,6 +57,10 @@ func (svc *Service) IsTombstone() bool {
 	return svc.Status == TOMBSTONE
 }
 
+func (svc *Service) IsDraining() bool {
+	return svc.Status == DRAINING
+}
+
 func (svc *Service) Invalidates(otherSvc *Service) bool {
 	return otherSvc != nil && svc.Updated.After(otherSvc.Updated)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ const (
 	TOMBSTONE = iota
 	UNHEALTHY = iota
 	UNKNOWN   = iota
+	DRAINING  = iota
 )
 
 type Port struct {
@@ -162,6 +163,8 @@ func StatusString(status int) string {
 		return "Unhealthy"
 	case UNKNOWN:
 		return "Unknown"
+	case DRAINING:
+		return "Draining"
 	default:
 		return "Tombstone"
 	}

--- a/services_delegate.go
+++ b/services_delegate.go
@@ -50,7 +50,7 @@ func (d *servicesDelegate) Start() {
 				log.Errorf("Start(): error decoding message: %s", err)
 				continue
 			}
-			d.state.ServiceMsgs <- *entry
+			d.state.UpdateService(*entry)
 		}
 	}()
 

--- a/sidecarhttp/envoy_api_test.go
+++ b/sidecarhttp/envoy_api_test.go
@@ -2,8 +2,6 @@ package sidecarhttp
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -289,13 +287,4 @@ func Test_listenersHandler(t *testing.T) {
 
 		})
 	})
-}
-
-// getResult fetchs the status code, headers, and body from a recorder
-func getResult(recorder *httptest.ResponseRecorder) (code int, headers *http.Header, body string) {
-	resp := recorder.Result()
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-	body = string(bodyBytes)
-
-	return resp.StatusCode, &resp.Header, body
 }

--- a/sidecarhttp/http_test.go
+++ b/sidecarhttp/http_test.go
@@ -1,0 +1,16 @@
+package sidecarhttp
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+)
+
+// getResult fetches the status code, headers, and body from a recorder
+func getResult(recorder *httptest.ResponseRecorder) (code int, headers *http.Header, body string) {
+	resp := recorder.Result()
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	body = string(bodyBytes)
+
+	return resp.StatusCode, &resp.Header, body
+}

--- a/ui/app/services/services.html
+++ b/ui/app/services/services.html
@@ -54,8 +54,8 @@
             <th>Created</th><th>Updated</th><th>Status</th>
           </tr>
 
-          <tr ng-repeat="group in services" 
-              ng-class="{'success': group[0].Status == 0, 'warning': group[0].Status == 1, 'danger': group[0].Status == 2 }"
+          <tr ng-repeat="group in services"
+              ng-class="{'success': group[0].Status == 0, 'warning': group[0].Status == 1, 'danger': group[0].Status == 2, 'info': group[0].Status == 4 }"
               class="group-row">
             <td>
               <span class="service-badge badge">{{ group.length }}</span>
@@ -88,8 +88,8 @@
               <th>Created</th><th>Updated</th><th>Status</th>
             </tr>
 
-            <tr ng-repeat="svc in group" 
-                ng-class="{'success': group[0].Status == 0, 'warning': group[0].Status == 1, 'danger': group[0].Status == 2 }"
+            <tr ng-repeat="svc in group"
+                ng-class="{'success': group[0].Status == 0, 'warning': group[0].Status == 1, 'danger': group[0].Status == 2, 'info': group[0].Status == 4 }"
                 class="group-row">
               <td>{{ svc.Hostname }}</td>
               <td>{{ svc.Image | extractTag }}</td>

--- a/ui/app/services/services.js
+++ b/ui/app/services/services.js
@@ -12,13 +12,13 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 .factory('stateService', function($http, $q) {
 	function svcGetServices() {
       return $http({
-        method: 'GET', 
+        method: 'GET',
         url: '/api/services.json',
 		dataType: 'json',
       });
     };
 
-	var haproxyUrl = window.location.protocol + 
+	var haproxyUrl = window.location.protocol +
 		'//' + window.location.hostname +
 		':3212/;csv;norefresh';
 
@@ -185,7 +185,7 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 				ports.push(port.Port.toString())
 			}
 		}
-	
+
 		return ports.join(", ")
 	};
 })
@@ -199,6 +199,8 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 	        return "Unhealthy"
 	    case 3:
 	        return "Unknown"
+	    case 4:
+	        return "Draining"
 	    default:
 	        return "Tombstone"
 	    }
@@ -218,9 +220,9 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 		if (seconds > 630720000) { // More than 20 years ago
 			return "never";
 		}
-	
+
 	    var interval = Math.floor(seconds / 31536000);
-	
+
 	    if (interval > 1) {
 	        return interval + " years ago";
 	    }
@@ -275,11 +277,11 @@ if ( ! Array.prototype.groupBy) {
     this.forEach(function(o) {
       var group = JSON.stringify(f(o));
       groups[group] = groups[group] || [];
-      groups[group].push(o);  
+      groups[group].push(o);
     });
-    
+
     return Object.keys(groups).map(function (group) {
-      return groups[group]; 
-    }); 
-  }; 
+      return groups[group];
+    });
+  };
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "devDependencies": {
     "bower": "^1.7.7",
-    "http-server": "^0.9.0",
+    "http-server": "^0.10.0",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",


### PR DESCRIPTION
Hey @relistan this is a WIP of your notes from #44.

I believe this covers the required functionality except the following two items:
- [x] propagating `DRAINING` services via gossip messages faster, similar to `TOMBSTONE` mentioned [here](https://github.com/Nitro/sidecar/pull/44#issuecomment-473274782).
  - [this code](https://github.com/Nitro/sidecar/blob/8912f899907a44f2c1ca969d00aeff7422b8ad61/catalog/services_state.go#L474-L476) in `IsNewService` returns true for `DRAINING` services. This happens because BroadcastServices will get the servicesList from `monitor.Services()`, which will return the service with status `ALIVE` due to the healthcheck. Then `svc.Status` will be `ALIVE` and `found.Status` will be `DRAINING`, so the `if` statement succeeds. I see the `DRAINING` state propagating in under 10 seconds in a test environment, so that should be fine.
- [x] setting a lifespan for the `DRAINING` status (similar to [`ALIVE_LIFESPAN`](https://github.com/Nitro/sidecar/blob/ad91abec576825b1d6a57d2f0fd88c9d5fc1f888/catalog/services_state.go#L32) as you pointed out [here](https://github.com/Nitro/sidecar/pull/44#issuecomment-473279314)).

I'll continue digging through the code to see how much would need to be changed for these.

Please let me know what you think so far.

LE: I bumped into a npm [leftpad issue](https://github.com/jfhbrook/node-ecstatic/issues/255) today, so I had to update the `http-server` dependency in the UI.