### PR TITLE
Add service DRAINING status and a handler for the `drain` HTTP API endpoint

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -325,6 +325,22 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 	}
 }
 
+// Returns a service for a given ID if it happens to exist on the current
+// host. Returns an error otherwise.
+func (state *ServicesState) GetServiceByID(id string) (service.Service, error) {
+	state.RLock()
+	defer state.RUnlock()
+
+	if server, ok := state.Servers[state.Hostname]; ok {
+		if svc, ok := server.Services[id]; ok {
+			return *svc, nil
+		}
+	}
+
+	return service.Service{},
+		fmt.Errorf("service with ID %q not found on host %q", id, state.Hostname)
+}
+
 // Merge a complete state struct into this one. Usually used on
 // node startup and during anti-entropy operations.
 func (state *ServicesState) Merge(otherState *ServicesState) {

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -219,6 +219,33 @@ func Test_ServicesStateWithData(t *testing.T) {
 				}
 				So(pendingBroadcast, ShouldBeFalse)
 			})
+
+			Convey("Sets a service's status to DRAINING", func() {
+				state.AddServiceEntry(svc)
+
+				svc.Status = service.DRAINING
+				svc.Updated = time.Now().UTC()
+
+				state.AddServiceEntry(svc)
+
+				So(state.HasServer(anotherHostname), ShouldBeTrue)
+				So(state.Servers[anotherHostname].Services[svc.ID].Status,
+					ShouldEqual, service.DRAINING)
+			})
+
+			Convey("Doesn't mark a DRAINING service as ALIVE", func() {
+				svc.Status = service.DRAINING
+				state.AddServiceEntry(svc)
+
+				svc.Status = service.ALIVE
+				svc.Updated = time.Now().UTC()
+
+				state.AddServiceEntry(svc)
+
+				So(state.HasServer(anotherHostname), ShouldBeTrue)
+				So(state.Servers[anotherHostname].Services[svc.ID].Status,
+					ShouldEqual, service.DRAINING)
+			})
 		})
 
 		Convey("Merge() merges state we care about from other state structs", func() {

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -248,6 +248,32 @@ func Test_ServicesStateWithData(t *testing.T) {
 			})
 		})
 
+		Convey("GetServiceByID()", func() {
+			Convey("Returns an existing service on the current host", func() {
+				state.Hostname = anotherHostname
+				state.AddServiceEntry(svc)
+
+				returnedSvc, err := state.GetServiceByID(svc.ID)
+				So(err, ShouldBeNil)
+				So(returnedSvc.ID, ShouldEqual, svc.ID)
+			})
+
+			Convey("Doesn't return a service running on other hosts", func() {
+				state.AddServiceEntry(svc)
+
+				_, err := state.GetServiceByID(svc.ID)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Returns an error for a non-existent service ID", func() {
+				state.AddServiceEntry(svc)
+
+				_, err := state.GetServiceByID("missing")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "not found")
+			})
+		})
+
 		Convey("Merge() merges state we care about from other state structs", func() {
 			firstState := NewServicesState()
 			secondState := NewServicesState()

--- a/healthy/healthy.go
+++ b/healthy/healthy.go
@@ -11,15 +11,16 @@ import (
 	"time"
 
 	"github.com/Nitro/sidecar/service"
-	log "github.com/sirupsen/logrus"
 	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
-	HEALTHY = 0
-	SICKLY  = iota
-	FAILED  = iota
-	UNKNOWN = iota
+	HEALTHY  = 0
+	SICKLY   = iota
+	FAILED   = iota
+	UNKNOWN  = iota
+	DRAINING = iota
 )
 
 const (
@@ -118,6 +119,8 @@ func (check *Check) ServiceStatus() int {
 	case HEALTHY:
 		return service.ALIVE
 	case SICKLY:
+		return service.ALIVE
+	case DRAINING:
 		return service.ALIVE
 	case UNKNOWN:
 		return service.UNKNOWN

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -47,6 +47,8 @@ func ShouldNotify(oldStatus int, newStatus int) bool {
 	switch newStatus {
 	case service.ALIVE:
 		return true
+	case service.DRAINING:
+		return true
 	case service.TOMBSTONE:
 		return true
 	case service.UNKNOWN:

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ const (
 	TOMBSTONE = iota
 	UNHEALTHY = iota
 	UNKNOWN   = iota
+	DRAINING  = iota
 )
 
 type Port struct {
@@ -162,6 +163,8 @@ func StatusString(status int) string {
 		return "Unhealthy"
 	case UNKNOWN:
 		return "Unknown"
+	case DRAINING:
+		return "Draining"
 	default:
 		return "Tombstone"
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -58,7 +58,9 @@ func (svc *Service) IsTombstone() bool {
 }
 
 func (svc *Service) Invalidates(otherSvc *Service) bool {
-	return otherSvc != nil && svc.Updated.After(otherSvc.Updated)
+	return otherSvc != nil &&
+		svc.Updated.After(otherSvc.Updated) &&
+		!(otherSvc.Status == DRAINING && svc.Status == ALIVE)
 }
 
 func (svc *Service) Format() string {

--- a/services_delegate.go
+++ b/services_delegate.go
@@ -50,7 +50,7 @@ func (d *servicesDelegate) Start() {
 				log.Errorf("Start(): error decoding message: %s", err)
 				continue
 			}
-			d.state.ServiceMsgs <- *entry
+			d.state.UpdateService(*entry)
 		}
 	}()
 

--- a/sidecarhttp/envoy_api_test.go
+++ b/sidecarhttp/envoy_api_test.go
@@ -2,8 +2,6 @@ package sidecarhttp
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -289,13 +287,4 @@ func Test_listenersHandler(t *testing.T) {
 
 		})
 	})
-}
-
-// getResult fetchs the status code, headers, and body from a recorder
-func getResult(recorder *httptest.ResponseRecorder) (code int, headers *http.Header, body string) {
-	resp := recorder.Result()
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-	body = string(bodyBytes)
-
-	return resp.StatusCode, &resp.Header, body
 }

--- a/sidecarhttp/http_api.go
+++ b/sidecarhttp/http_api.go
@@ -35,6 +35,7 @@ type SidecarApi struct {
 func (s *SidecarApi) HttpMux() http.Handler {
 	router := mux.NewRouter()
 	router.HandleFunc("/services/{name}.{extension}", wrap(s.oneServiceHandler)).Methods("GET")
+	router.HandleFunc("/services/{id}/drain", wrap(s.drainServiceHandler)).Methods("POST")
 	router.HandleFunc("/services.{extension}", wrap(s.servicesHandler)).Methods("GET")
 	router.HandleFunc("/state.{extension}", wrap(s.stateHandler)).Methods("GET")
 	router.HandleFunc("/watch", wrap(s.watchHandler)).Methods("GET")
@@ -286,6 +287,46 @@ func (s *SidecarApi) stateHandler(response http.ResponseWriter, req *http.Reques
 	_, err := response.Write(s.state.Encode())
 	if err != nil {
 		log.Errorf("Error writing state response to client: %s", err)
+	}
+}
+
+// drainServiceHandler instructs Sidecar to set the status of a given service
+// instance to DRAINING. This allows us to decomission the given service
+// instance and let it sit around for a short amount of time, so it can finish
+// processing the requests that are still in flight.
+func (s *SidecarApi) drainServiceHandler(response http.ResponseWriter, req *http.Request, params map[string]string) {
+	defer req.Body.Close()
+
+	if req.Method != http.MethodPost {
+		sendJsonError(response, 400, fmt.Sprintf("Bad request - Method %q not allowed", req.Method))
+		return
+	}
+
+	serviceID, ok := params["id"]
+	if !ok {
+		sendJsonError(response, 404, "Not Found - No service ID provided")
+		return
+	}
+
+	if s.state == nil {
+		sendJsonError(response, 500, "Internal Server Error - Something went terribly wrong")
+		return
+	}
+
+	svc, err := s.state.GetServiceByID(serviceID)
+	if err != nil {
+		sendJsonError(response, 404, fmt.Sprintf("Not Found - Service ID %q not found", serviceID))
+		return
+	}
+
+	svc.Updated = time.Now()
+	svc.Status = service.DRAINING
+	s.state.UpdateService(svc)
+
+	response.WriteHeader(202)
+	_, err = response.Write([]byte(fmt.Sprintf("Service %q instance %q set to DRAINING", svc.Name, svc.ID)))
+	if err != nil {
+		log.Errorf("Error writing drain service response to client: %s", err)
 	}
 }
 

--- a/sidecarhttp/utils.go
+++ b/sidecarhttp/utils.go
@@ -1,0 +1,16 @@
+package sidecarhttp
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+)
+
+// getResult fetches the status code, headers, and body from a recorder
+func getResult(recorder *httptest.ResponseRecorder) (code int, headers *http.Header, body string) {
+	resp := recorder.Result()
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	body = string(bodyBytes)
+
+	return resp.StatusCode, &resp.Header, body
+}

--- a/ui/app/services/services.js
+++ b/ui/app/services/services.js
@@ -12,13 +12,13 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 .factory('stateService', function($http, $q) {
 	function svcGetServices() {
       return $http({
-        method: 'GET', 
+        method: 'GET',
         url: '/api/services.json',
 		dataType: 'json',
       });
     };
 
-	var haproxyUrl = window.location.protocol + 
+	var haproxyUrl = window.location.protocol +
 		'//' + window.location.hostname +
 		':3212/;csv;norefresh';
 
@@ -185,7 +185,7 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 				ports.push(port.Port.toString())
 			}
 		}
-	
+
 		return ports.join(", ")
 	};
 })
@@ -199,6 +199,8 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 	        return "Unhealthy"
 	    case 3:
 	        return "Unknown"
+	    case 4:
+	        return "Draining"
 	    default:
 	        return "Tombstone"
 	    }
@@ -218,9 +220,9 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 		if (seconds > 630720000) { // More than 20 years ago
 			return "never";
 		}
-	
+
 	    var interval = Math.floor(seconds / 31536000);
-	
+
 	    if (interval > 1) {
 	        return interval + " years ago";
 	    }
@@ -275,11 +277,11 @@ if ( ! Array.prototype.groupBy) {
     this.forEach(function(o) {
       var group = JSON.stringify(f(o));
       groups[group] = groups[group] || [];
-      groups[group].push(o);  
+      groups[group].push(o);
     });
-    
+
     return Object.keys(groups).map(function (group) {
-      return groups[group]; 
-    }); 
-  }; 
+      return groups[group];
+    });
+  };
 }


### PR DESCRIPTION
Hey @relistan this is a WIP of your notes from #44.

I believe this covers the required functionality except the following two items:
- [ ] propagating `DRAINING` services via gossip messages faster, similar to `TOMBSTONE`, as you mentioned [here](https://github.com/Nitro/sidecar/pull/44#issuecomment-473274782).
- [ ] setting a lifespan for the `DRAINING` status (similar to [`ALIVE_LIFESPAN`](https://github.com/Nitro/sidecar/blob/ad91abec576825b1d6a57d2f0fd88c9d5fc1f888/catalog/services_state.go#L32) as you pointed out [here](https://github.com/Nitro/sidecar/pull/44#issuecomment-473279314)).

I'll continue digging through the code to see how much would need to be changed for these.

Please let me know what you think so far.

I'm curious if 237242e is what you had in mind for preventing Sidecar's normal processing loop from flipping the `DRAINING` state back to `ALIVE`.

Also, is `UpdateService` from 445e56c the "light wrapper" that you were thinking of [here](https://github.com/Nitro/sidecar/pull/44#discussion_r266197689)?

Finally, I didn't see any way to avoid querying the state for the given service by ID in `drainServiceHandler`, so I implemented `ServicesState.GetServiceByID` in 0a8e8a2. It looks like we need to push the whole service metadata as a state update on `state.ServiceMsgs`, but please let me know if I'm wrong.