### PR TITLE
Skip Envoy HTTPConnectionManager cluster validation and simplify Envoy server code

### DIFF
--- a/envoy/adapter/adapter.go
+++ b/envoy/adapter/adapter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -169,6 +170,7 @@ func envoyListenerFromService(svc *service.Service, envoyServiceName string,
 			}},
 			RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{
 				RouteConfig: &api.RouteConfiguration{
+					ValidateClusters: &wrappers.BoolValue{Value: false},
 					VirtualHosts: []*route.VirtualHost{{
 						Name:    envoyServiceName,
 						Domains: []string{"*"},


### PR DESCRIPTION
When I implemented the Envoy adapter, I didn't notice this `validate_clusters` field in the `HTTP route configuration` (see [here](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route.proto#envoy-api-msg-routeconfiguration)). Although the docs say that "this setting default to false if the route table is loaded dynamically via the rds option", for some reason it seems to be set to `true` when the connection manager is of type `HTTPConnectionManager` and `false` when the connection manager is of type `TcpProxy`. The reason I added all that custom logic in server.go was to avoid Envoy spewing out errors and rejecting listeners for which clusters haven't been created yet because the go-control-plane sends listener and cluster updates to Envoy independently without a predefined order. With `validate_clusters` set to `false`, Envoy doesn't complain any more and it all seems to work fine with both Envoy v1.8.0 and v1.15.0.

Also, Istio seems to set this to `false` explicitly in their code when building `RouteConfiguration`s: https://github.com/istio/istio/blob/f7fbc8043c3b3a1d020ac87d28334509003ef4c4/pilot/pkg/networking/core/v1alpha3/httproute.go#L61

Might be worth mentioning that the Envoy docs state that "if set to false and a route refers to a non-existent cluster, the route table will load and the router filter will return a 404 if the route is selected at runtime", which seems incorrect from my tests, because Envoy returns 503 instead of 404 in such cases.