### PR TITLE
Fix Envoy gRPC API listener names

### DIFF
--- a/envoy/adapter/adapter.go
+++ b/envoy/adapter/adapter.go
@@ -172,7 +172,7 @@ func envoyListenerFromService(svc *service.Service, envoyServiceName string,
 				RouteConfig: &api.RouteConfiguration{
 					ValidateClusters: &wrappers.BoolValue{Value: false},
 					VirtualHosts: []*route.VirtualHost{{
-						Name:    envoyServiceName,
+						Name:    svc.Name,
 						Domains: []string{"*"},
 						Routes: []*route.Route{{
 							Match: &route.RouteMatch{
@@ -214,7 +214,7 @@ func envoyListenerFromService(svc *service.Service, envoyServiceName string,
 	}
 
 	return &api.Listener{
-		Name: svc.Name,
+		Name: envoyServiceName,
 		Address: &core.Address{
 			Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{

--- a/envoy/server_test.go
+++ b/envoy/server_test.go
@@ -43,7 +43,7 @@ func validateListener(serialisedListener *any.Any, svc service.Service) {
 	listener := &api.Listener{}
 	err := ptypes.UnmarshalAny(serialisedListener, listener)
 	So(err, ShouldBeNil)
-	So(listener.Name, ShouldEqual, svc.Name)
+	So(listener.Name, ShouldEqual, adapter.SvcName(svc.Name, svc.Ports[0].ServicePort))
 	So(listener.GetAddress().GetSocketAddress().GetAddress(), ShouldEqual, bindIP)
 	So(listener.GetAddress().GetSocketAddress().GetPortValue(), ShouldEqual, svc.Ports[0].ServicePort)
 	filterChains := listener.GetFilterChains()


### PR DESCRIPTION
The listener names need to be unique for each service port and the virtual host names need to be set to the service name, just like in the legacy JSON REST API implementation.