### PR TITLE
Use EDS clusters for the Envoy gRPC API

### DIFF
--- a/envoy/server.go
+++ b/envoy/server.go
@@ -91,7 +91,7 @@ func (s *Server) Run(ctx context.Context, looper director.Looper, grpcListener n
 		snapshotVersion := newSnapshotVersion()
 		err := s.snapshotCache.SetSnapshot(hostname, cache.NewSnapshot(
 			snapshotVersion,
-			nil,
+			resources.Endpoints,
 			resources.Clusters,
 			nil,
 			resources.Listeners,
@@ -102,8 +102,8 @@ func (s *Server) Run(ctx context.Context, looper director.Looper, grpcListener n
 			return nil
 		}
 
-		log.Infof("Sent %d listeners and %d clusters to Envoy with version %s",
-			len(resources.Listeners), len(resources.Clusters), snapshotVersion,
+		log.Infof("Sent %d endpoints, %d listeners and %d clusters to Envoy with version %s",
+			len(resources.Endpoints), len(resources.Listeners), len(resources.Clusters), snapshotVersion,
 		)
 
 		return nil

--- a/envoy/server_test.go
+++ b/envoy/server_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/Nitro/sidecar/service"
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	tcpp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	envoy_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
-	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
@@ -53,22 +54,26 @@ func validateListener(serialisedListener *any.Any, svc service.Service) {
 
 	if svc.ProxyMode == "http" {
 		So(filters[0].GetName(), ShouldEqual, wellknown.HTTPConnectionManager)
-		// TODO: Switch to ptypes.MarshalAny when updating the Envoy API
-		// See the original implementation from 080e510
-		//nolint:staticcheck // ignore SA1019 for deprecated code
-		connectionManager, err := conversion.MessageToStruct(filters[0].GetConfig())
+		connectionManager := &hcm.HttpConnectionManager{}
+		err = ptypes.UnmarshalAny(filters[0].GetTypedConfig(), connectionManager)
 		So(err, ShouldBeNil)
-		So(connectionManager, ShouldNotBeZeroValue)
-		So(connectionManager.GetFields()["stat_prefix"].GetStringValue(), ShouldEqual, "ingress_http")
+		So(connectionManager.GetStatPrefix(), ShouldEqual, "ingress_http")
+		So(connectionManager.GetRouteConfig(), ShouldNotBeNil)
+		So(connectionManager.GetRouteConfig().GetVirtualHosts(), ShouldHaveLength, 1)
+		virtualHost := connectionManager.GetRouteConfig().GetVirtualHosts()[0]
+		So(virtualHost.GetName(), ShouldEqual, svc.Name)
+		So(virtualHost.GetRoutes(), ShouldHaveLength, 1)
+		route := virtualHost.GetRoutes()[0].GetRoute()
+		So(route, ShouldNotBeNil)
+		So(route.GetCluster(), ShouldEqual, adapter.SvcName(svc.Name, svc.Ports[0].ServicePort))
+		So(route.GetTimeout(), ShouldNotBeNil)
 	} else { // tcp
 		So(filters[0].GetName(), ShouldEqual, wellknown.TCPProxy)
-		// TODO: Switch to ptypes.MarshalAny when updating the Envoy API
-		// See the original implementation from 080e510
-		//nolint:staticcheck // ignore SA1019 for deprecated code
-		connectionManager, err := conversion.MessageToStruct(filters[0].GetConfig())
+		connectionManager := &tcpp.TcpProxy{}
+		err = ptypes.UnmarshalAny(filters[0].GetTypedConfig(), connectionManager)
 		So(err, ShouldBeNil)
-		So(connectionManager.GetFields()["stat_prefix"].GetStringValue(), ShouldEqual, "ingress_tcp")
-		So(connectionManager.GetFields()["cluster"].GetStringValue(), ShouldEqual, adapter.SvcName(svc.Name, svc.Ports[0].ServicePort))
+		So(connectionManager.GetStatPrefix(), ShouldEqual, "ingress_tcp")
+		So(connectionManager.GetCluster(), ShouldEqual, adapter.SvcName(svc.Name, svc.Ports[0].ServicePort))
 	}
 }
 


### PR DESCRIPTION
This allows ADS to retrieve endpoints directly if needed. The dynamic clusters returned by CDS use EDS discovery, so they have to fetch their endpoints via ADS instead of having them embedded directly as before.

Also remove deprecated APIs for the Envoy gRPC API.

These changes require Envoy v1.12.0+.